### PR TITLE
API Authorize URL | Show Dialog Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .idea/
 *.iml
 target/
+.settings/
+.project
+.classpath
 .DS_Store

--- a/src/main/java/com/wrapper/spotify/Api.java
+++ b/src/main/java/com/wrapper/spotify/Api.java
@@ -433,6 +433,32 @@ public class Api {
    * @param scopes The scopes corresponding to the permissions the application needs
    * @param state state A parameter that you can use to maintain a value between the request
    *              and the callback to redirect_uri.It is useful to prevent CSRF exploits.
+   * @param showDialog - (optional) whether or not to force the user to login
+   * @return The URL where the user can give application permissions.
+   */
+  public String createAuthorizeURL(List<String> scopes, String state, boolean showDialog) {
+    final AuthorizationURLRequest.Builder builder = AuthorizationURLRequest.builder();
+    setDefaults(builder);
+    builder.clientId(clientId);
+    builder.responseType("code");
+    builder.redirectURI(redirectURI);
+    if (scopes != null) {
+      builder.scopes(scopes);
+    }
+    if (state != null) {
+      builder.state(state);
+    }
+
+    builder.showDialog(showDialog);
+    
+    return builder.build().toStringWithQueryParameters();
+  }
+  
+  /**
+   * Retrieve a URL where the user can give the application permissions.
+   * @param scopes The scopes corresponding to the permissions the application needs
+   * @param state state A parameter that you can use to maintain a value between the request
+   *              and the callback to redirect_uri.It is useful to prevent CSRF exploits.
    * @return The URL where the user can give application permissions.
    */
   public String createAuthorizeURL(List<String> scopes, String state) {

--- a/src/test/java/com/wrapper/spotify/ApiTest.java
+++ b/src/test/java/com/wrapper/spotify/ApiTest.java
@@ -481,6 +481,24 @@ public class ApiTest {
 
     assertEquals("https://accounts.spotify.com:443/authorize?client_id=fcecfc79122e4cd299473677a17cbd4d&response_type=code&redirect_uri=http://www.michaelthelin.se/test-callback&scope=user-read-private%20user-read-email&state=someExpectedStateString&show_dialog=false", authorizeURL);
   }
+  
+  @Test
+  public void shouldCreateAuthorizeUrlWithShowDialogAndOptionalParameters() {
+    final String redirectURI = "http://www.michaelthelin.se/test-callback";
+    final String clientId = "fcecfc79122e4cd299473677a17cbd4d";
+
+    final Api api = Api.builder()
+        .clientId(clientId)
+        .redirectURI(redirectURI)
+        .build();
+
+    final List<String> scopes = Arrays.asList("user-read-private", "user-read-email");
+    final String state = "someExpectedStateString";
+
+    String authorizeURL = api.createAuthorizeURL(scopes, state, true);
+
+    assertEquals("https://accounts.spotify.com:443/authorize?client_id=fcecfc79122e4cd299473677a17cbd4d&response_type=code&redirect_uri=http://www.michaelthelin.se/test-callback&scope=user-read-private%20user-read-email&state=someExpectedStateString&show_dialog=true", authorizeURL);
+  }
 
   @Test
   public void shouldCreateGetMyTracksURL() {


### PR DESCRIPTION
Updated the api call to support passing in true/false for show_dialog parameter. This can be used to force a user to sign in and ignore cookies from browser. Very useful.
I also updated the gitignore to ignore eclipse files (yeah i have not converted to intellij lol)
