### PR TITLE
Adding a method to get all tracks given an album

### DIFF
--- a/src/main/java/com/wrapper/spotify/Api.java
+++ b/src/main/java/com/wrapper/spotify/Api.java
@@ -151,6 +151,13 @@ public class Api {
     builder.id(ids);
     return builder;
   }
+  
+  public TracksForAlbumRequest.Builder getTracksForAlbum(String albumName) {
+	TracksForAlbumRequest.Builder builder = TracksForAlbumRequest.builder();
+	setDefaults(builder);
+	builder.forAlbum(albumName);
+	return builder;
+  }
 
   public AlbumSearchRequest.Builder searchAlbums(String query) {
     AlbumSearchRequest.Builder builder = AlbumSearchRequest.builder();

--- a/src/main/java/com/wrapper/spotify/JsonUtil.java
+++ b/src/main/java/com/wrapper/spotify/JsonUtil.java
@@ -397,7 +397,7 @@ public class JsonUtil {
     return page;
   }
 
-  private static Page<SimpleTrack> createSimpleTrackPage(JSONObject simpleTrackPageJson) {
+  public static Page<SimpleTrack> createSimpleTrackPage(JSONObject simpleTrackPageJson) {
     Page page = createItemlessPage(simpleTrackPageJson);
     page.setItems(createSimpleTracks(simpleTrackPageJson.getJSONArray("items")));
     return page;

--- a/src/main/java/com/wrapper/spotify/methods/TracksForAlbumRequest.java
+++ b/src/main/java/com/wrapper/spotify/methods/TracksForAlbumRequest.java
@@ -1,0 +1,73 @@
+package com.wrapper.spotify.methods;
+
+import com.google.common.util.concurrent.SettableFuture;
+import net.sf.json.JSONObject;
+import com.wrapper.spotify.JsonUtil;
+import com.wrapper.spotify.exceptions.*;
+import com.wrapper.spotify.models.Page;
+import com.wrapper.spotify.models.SimpleTrack;
+
+import java.io.IOException;
+
+public class TracksForAlbumRequest extends AbstractRequest {
+
+	public TracksForAlbumRequest(Builder builder) {
+		super(builder);
+	}
+
+	public SettableFuture<Page<SimpleTrack>> getAsync() {
+		SettableFuture<Page<SimpleTrack>> searchResultFuture = SettableFuture.create();
+
+		try {
+			final String jsonString = getJson();
+			final JSONObject jsonObject = JSONObject.fromObject(jsonString);
+
+			searchResultFuture.set(JsonUtil.createSimpleTrackPage(jsonObject));
+		} catch (Exception e) {
+			searchResultFuture.setException(e);
+		}
+
+		return searchResultFuture;
+	}
+
+	public Page<SimpleTrack> get() throws IOException, WebApiException {
+		final String jsonString = getJson();
+		final JSONObject jsonObject = JSONObject.fromObject(jsonString);
+		return JsonUtil.createSimpleTrackPage((JSONObject) jsonObject.get("tracks"));
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder extends AbstractRequest.Builder<Builder> {
+
+		public Builder forAlbum(String albumName) {
+			assert (albumName != null);
+			path("/v1/search");
+			parameter("type", "track");
+			return parameter("q", "album:" + albumName);
+		}
+
+		public Builder market(String market) {
+			assert (market != null);
+			return parameter("market", market);
+		}
+
+		public Builder limit(int limit) {
+			assert (limit > 0);
+			return parameter("limit", String.valueOf(limit));
+		}
+
+		public Builder offset(int offset) {
+			assert (offset >= 0);
+			return parameter("offset", String.valueOf(offset));
+		}
+
+		public TracksForAlbumRequest build() {
+			return new TracksForAlbumRequest(this);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Small change to have an option to find tracks given an album, something like:

https://api.spotify.com:443/v1/search?q=album:Sonic%20Highways&type=track



