### PR TITLE
Javadoc Requests (2/2)

### DIFF
--- a/src/main/java/com/wrapper/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequest.java
@@ -9,12 +9,38 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 import java.io.IOException;
 import java.util.Date;
 
+/**
+ * Get tracks from the current user’s recently played tracks.
+ * <p>
+ * Returns the most recent 50 tracks played by a user. Note that a track currently playing will not be visible in play
+ * history until it has completed. A track must be played for more than 30 seconds to be included in play history.
+ * <p>
+ * Any tracks listened to while the user had "Private Session" enabled in their client will not be returned in the list
+ * of recently played tracks.
+ *
+ * The endpoint uses a bidirectional cursor for paging. Follow the {@code next} field with the {@code before} parameter
+ * to move back in time, or use the after parameter to move forward in time. If you supply no {@code before} or
+ * {@code after} parameter, the endpoint  will return the most recently played songs, and the {@code next}
+ * link will page back in time.
+ */
 public class GetCurrentUsersRecentlyPlayedTracksRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetCurrentUsersRecentlyPlayedTracksRequest} constructor.
+   *
+   * @param builder A {@link GetCurrentUsersRecentlyPlayedTracksRequest.Builder}.
+   */
   private GetCurrentUsersRecentlyPlayedTracksRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get an user's recently played tracks.
+   *
+   * @return An user's recently played tracks.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public PagingCursorbased<PlayHistory> execute() throws
           IOException,
@@ -22,28 +48,65 @@ public class GetCurrentUsersRecentlyPlayedTracksRequest extends AbstractDataRequ
     return new PlayHistory.JsonUtil().createModelObjectPagingCursorbased(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetCurrentUsersRecentlyPlayedTracksRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetCurrentUsersRecentlyPlayedTracksRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-read-recently-played} scope authorized in order to read
+     * the user's recently played track.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link GetCurrentUsersRecentlyPlayedTracksRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (limit != null);
       assert (1 <= limit && limit <= 50);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The after date setter.
+     *
+     * @param after Optional. A {@link Date} object. Returns all items after (but not including) this cursor position.
+     *              If {@link #after(Date)} is specified, {@link #before(Date)} must not be specified.
+     * @return A {@link GetCurrentUsersRecentlyPlayedTracksRequest.Builder}.
+     */
     public Builder after(final Date after) {
       assert (after != null);
       return setQueryParameter("after", SpotifyApi.SIMPLE_DATE_FORMAT.format(after));
     }
 
+    /**
+     * The before date setter.
+     *
+     * @param before Optional. A {@link Date} object. Returns all items before (but not including) this cursor position.
+     *              If {@link #before(Date)} is specified, {@link #after(Date)} must not be specified.
+     * @return A {@link GetCurrentUsersRecentlyPlayedTracksRequest.Builder}.
+     */
     public Builder before(final Date before) {
       assert (before != null);
       return setQueryParameter("before", SpotifyApi.SIMPLE_DATE_FORMAT.format(before));
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetCurrentUsersRecentlyPlayedTracksRequest}.
+     */
     @Override
     public GetCurrentUsersRecentlyPlayedTracksRequest build() {
       setPath("/v1/me/player/recently-played");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequest.java
@@ -7,12 +7,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get information about the user’s current playback state, including track, track progress, and active device.
+ */
 public class GetInformationAboutUsersCurrentPlaybackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetInformationAboutUsersCurrentPlaybackRequest} constructor.
+   *
+   * @param builder A {@link GetInformationAboutUsersCurrentPlaybackRequest.Builder}.
+   */
   private GetInformationAboutUsersCurrentPlaybackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get information about a user's playback.
+   *
+   * @return Information about a users playback.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public CurrentlyPlayingContext execute() throws
           IOException,
@@ -20,17 +35,42 @@ public class GetInformationAboutUsersCurrentPlaybackRequest extends AbstractData
     return new CurrentlyPlayingContext.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetInformationAboutUsersCurrentPlaybackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetInformationAboutUsersCurrentPlaybackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-read-playback-state} scope authorized in order to read information.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. Provide this parameter if you
+     *               want to apply Track Relinking.
+     * @return A {@link GetInformationAboutUsersCurrentPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/track-relinking-guide/">Spotify: Track Relinking Guide</a>
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetInformationAboutUsersCurrentPlaybackRequest}.
+     */
     @Override
     public GetInformationAboutUsersCurrentPlaybackRequest build() {
       setPath("/v1/me/player");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/GetUsersAvailableDevicesRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/GetUsersAvailableDevicesRequest.java
@@ -6,24 +6,55 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get information about a user’s available devices.
+ */
 public class GetUsersAvailableDevicesRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetUsersAvailableDevicesRequest} constructor.
+   *
+   * @param builder A {@link GetUsersAvailableDevicesRequest.Builder}.
+   */
   private GetUsersAvailableDevicesRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get an user's available devices.
+   *
+   * @return An user's available devices.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   public Device[] execute() throws
           IOException,
           SpotifyWebApiException {
     return new Device.JsonUtil().createModelObjectArray(getJson(), "devices");
   }
 
+  /**
+   * Builder class for building a {@link GetUsersAvailableDevicesRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetUsersAvailableDevicesRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-read-playback-state} scope authorized in order to read information.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetUsersAvailableDevicesRequest}.
+     */
     @Override
     public GetUsersAvailableDevicesRequest build() {
       setPath("/v1/me/player/devices");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/GetUsersCurrentlyPlayingTrackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/GetUsersCurrentlyPlayingTrackRequest.java
@@ -7,12 +7,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get the object currently being played on the user’s Spotify account.
+ */
 public class GetUsersCurrentlyPlayingTrackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetUsersCurrentlyPlayingTrackRequest} constructor.
+   *
+   * @param builder A {@link GetUsersCurrentlyPlayingTrackRequest.Builder}.
+   */
   private GetUsersCurrentlyPlayingTrackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get an user's currently playing track.
+   *
+   * @return An user's currently playing track.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public CurrentlyPlaying execute() throws
           IOException,
@@ -20,17 +35,43 @@ public class GetUsersCurrentlyPlayingTrackRequest extends AbstractDataRequest {
     return new CurrentlyPlaying.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetUsersCurrentlyPlayingTrackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetUsersCurrentlyPlayingTrackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-read-currently-playing} scope and/or the
+     * {@code user-read-playback-state} authorized in order to read information.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. Provide this parameter if you
+     *               want to apply Track Relinking.
+     * @return A {@link GetUsersCurrentlyPlayingTrackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/track-relinking-guide/">Spotify: Track Relinking Guide</a>
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetUsersCurrentlyPlayingTrackRequest}.
+     */
     @Override
     public GetUsersCurrentlyPlayingTrackRequest build() {
       setPath("/v1/me/player/currently-playing");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/PauseUsersPlaybackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/PauseUsersPlaybackRequest.java
@@ -5,12 +5,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Pause playback on the user’s account.
+ */
 public class PauseUsersPlaybackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link PauseUsersPlaybackRequest} constructor.
+   *
+   * @param builder A {@link PauseUsersPlaybackRequest.Builder}.
+   */
   private PauseUsersPlaybackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Pause an user's playback.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,18 +33,42 @@ public class PauseUsersPlaybackRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link PauseUsersPlaybackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link PauseUsersPlaybackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link PauseUsersPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_id(final String device_id) {
       assert (device_id != null);
       assert (!device_id.equals(""));
       return setQueryParameter("device_id", device_id);
     }
 
+    /**
+     * The reuqest build method.
+     *
+     * @return A custom {@link PauseUsersPlaybackRequest}.
+     */
     @Override
     public PauseUsersPlaybackRequest build() {
       setPath("/v1/me/player/pause");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/SeekToPositionInCurrentlyPlayingTrackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/SeekToPositionInCurrentlyPlayingTrackRequest.java
@@ -5,12 +5,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Seeks to the given position in the user’s currently playing track.
+ */
 public class SeekToPositionInCurrentlyPlayingTrackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SeekToPositionInCurrentlyPlayingTrackRequest} constructor.
+   *
+   * @param builder A {@link SeekToPositionInCurrentlyPlayingTrackRequest.Builder}.
+   */
   private SeekToPositionInCurrentlyPlayingTrackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Seek to a position in the user's currently playing track.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,24 +33,56 @@ public class SeekToPositionInCurrentlyPlayingTrackRequest extends AbstractDataRe
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link SeekToPositionInCurrentlyPlayingTrackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SeekToPositionInCurrentlyPlayingTrackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The position setter.
+     *
+     * @param position_ms Required. The position in milliseconds to seek to. Must be a positive number. Passing in a
+     *                    position that is greater than the length of the track will cause the player to start
+     *                    playing the next song.
+     * @return A {@link SeekToPositionInCurrentlyPlayingTrackRequest.Builder}.
+     */
     public Builder position_ms(final Integer position_ms) {
       assert (position_ms != null);
       assert (position_ms >= 0);
       return setQueryParameter("position_ms", position_ms);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link SeekToPositionInCurrentlyPlayingTrackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_id(final String device_id) {
       assert (device_id != null);
       assert (!device_id.equals(""));
       return setQueryParameter("device_id", device_id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link SeekToPositionInCurrentlyPlayingTrackRequest}.
+     */
     @Override
     public SeekToPositionInCurrentlyPlayingTrackRequest build() {
       setPath("/v1/me/player/seek");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/SetRepeatModeOnUsersPlaybackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/SetRepeatModeOnUsersPlaybackRequest.java
@@ -5,12 +5,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Set the repeat mode for the user’s playback.
+ */
 public class SetRepeatModeOnUsersPlaybackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SetRepeatModeOnUsersPlaybackRequest} constructor.
+   *
+   * @param builder A {@link SetRepeatModeOnUsersPlaybackRequest.Builder}.
+   */
   private SetRepeatModeOnUsersPlaybackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Set the repeat mode on a user's playback.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,24 +33,55 @@ public class SetRepeatModeOnUsersPlaybackRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link SetRepeatModeOnUsersPlaybackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SetRepeatModeOnUsersPlaybackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The repeat state setter.
+     *
+     * @param state Required. {@code track}, {@code context} or {@code off}. {@code track} will repeat the current
+     *              track. {@code context} will repeat the current context. {@code off} will turn repeat off.
+     * @return A {@link SetRepeatModeOnUsersPlaybackRequest.Builder}.
+     */
     public Builder state(final String state) {
       assert (state != null);
       assert (state.equals("track") || state.equals("context") || state.equals("off"));
       return setQueryParameter("state", state);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link SetRepeatModeOnUsersPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_id(final String device_id) {
       assert (device_id != null);
       assert (!device_id.equals(""));
       return setQueryParameter("device_id", device_id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link SetRepeatModeOnUsersPlaybackRequest}.
+     */
     @Override
     public SetRepeatModeOnUsersPlaybackRequest build() {
       setPath("/v1/me/player/repeat");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/SetVolumeForUsersPlaybackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/SetVolumeForUsersPlaybackRequest.java
@@ -5,12 +5,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Set the volume for the user’s current playback device.
+ */
 public class SetVolumeForUsersPlaybackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SetVolumeForUsersPlaybackRequest} constructor.
+   *
+   * @param builder A {@link SetVolumeForUsersPlaybackRequest.Builder}.
+   */
   private SetVolumeForUsersPlaybackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Set the volume for the user’s current playback device.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,24 +33,54 @@ public class SetVolumeForUsersPlaybackRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link SetVolumeForUsersPlaybackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SetVolumeForUsersPlaybackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The volume percentage setter.
+     *
+     * @param volume_percent Required. The volume to set. Must be a value from 0 to 100 inclusive.
+     * @return A {@link SetVolumeForUsersPlaybackRequest.Builder}.
+     */
     public Builder volume_percent(final Integer volume_percent) {
       assert (volume_percent != null);
       assert (0 <= volume_percent && volume_percent >= 100);
       return setQueryParameter("volume_percent", volume_percent);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link SetVolumeForUsersPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_id(final String device_id) {
       assert (device_id != null);
       assert (!device_id.equals(""));
       return setQueryParameter("device_id", device_id);
     }
 
+    /**
+     * The build method.
+     *
+     * @return A custom {@link SetVolumeForUsersPlaybackRequest}.
+     */
     @Override
     public SetVolumeForUsersPlaybackRequest build() {
       setPath("/v1/me/player/volume");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/SkipUsersPlaybackToNextTrackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/SkipUsersPlaybackToNextTrackRequest.java
@@ -5,12 +5,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Skips to next track in the user’s queue.
+ */
 public class SkipUsersPlaybackToNextTrackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SkipUsersPlaybackToNextTrackRequest} constructor.
+   *
+   * @param builder A {@link SkipUsersPlaybackToNextTrackRequest.Builder}.
+   */
   private SkipUsersPlaybackToNextTrackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Skip to the next track in the user’s queue.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,18 +33,42 @@ public class SkipUsersPlaybackToNextTrackRequest extends AbstractDataRequest {
     return postJson();
   }
 
+  /**
+   * Builder class for building a {@link SkipUsersPlaybackToNextTrackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SkipUsersPlaybackToNextTrackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link SkipUsersPlaybackToNextTrackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_id(final String device_id) {
       assert (device_id != null);
       assert (!device_id.equals(""));
       return setQueryParameter("device_id", device_id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link SkipUsersPlaybackToNextTrackRequest}.
+     */
     @Override
     public SkipUsersPlaybackToNextTrackRequest build() {
       setPath("/v1/me/player/next");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/SkipUsersPlaybackToPreviousTrackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/SkipUsersPlaybackToPreviousTrackRequest.java
@@ -5,12 +5,31 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Skips to previous track in the user’s queue.
+ * <p>
+ * <b>Note:</b> This will ALWAYS skip to the previous track, regardless of the current track’s progress.
+ * Returning to the start of the current track should be performed using a
+ * {@link SeekToPositionInCurrentlyPlayingTrackRequest}.
+ */
 public class SkipUsersPlaybackToPreviousTrackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SkipUsersPlaybackToPreviousTrackRequest} constructor.
+   *
+   * @param builder A {@link SkipUsersPlaybackToPreviousTrackRequest.Builder}.
+   */
   private SkipUsersPlaybackToPreviousTrackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Skip to the previous track in the user’s queue.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,18 +37,42 @@ public class SkipUsersPlaybackToPreviousTrackRequest extends AbstractDataRequest
     return postJson();
   }
 
+  /**
+   * Builder class for building a {@link SkipUsersPlaybackToPreviousTrackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SkipUsersPlaybackToPreviousTrackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link SkipUsersPlaybackToPreviousTrackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_id(final String device_id) {
       assert (device_id != null);
       assert (!device_id.equals(""));
       return setQueryParameter("device_id", device_id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link SkipUsersPlaybackToPreviousTrackRequest}.
+     */
     @Override
     public SkipUsersPlaybackToPreviousTrackRequest build() {
       setPath("/v1/me/player/previous");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/StartResumeUsersPlaybackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/StartResumeUsersPlaybackRequest.java
@@ -7,12 +7,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Start a new context or resume current playback on the user’s active device.
+ */
 public class StartResumeUsersPlaybackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link StartResumeUsersPlaybackRequest} constructor.
+   *
+   * @param builder A {@link StartResumeUsersPlaybackRequest.Builder}.
+   */
   private StartResumeUsersPlaybackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Start or resume a playback.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -20,36 +35,90 @@ public class StartResumeUsersPlaybackRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link StartResumeUsersPlaybackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link StartResumeUsersPlaybackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link StartResumeUsersPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_id(final String device_id) {
       assert (device_id != null);
       assert (!device_id.equals(""));
       return setQueryParameter("device_id", device_id);
     }
 
+    /**
+     * The context URI setter.
+     *
+     * @param context_uri Optional. Spotify URI of the context to play.
+     *                    Valid contexts are albums, artists and playlists.
+     * @return A {@link StartResumeUsersPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder context_uri(final String context_uri) {
       assert (context_uri != null);
       assert (!context_uri.equals(""));
       return setBodyParameter("context_uri", context_uri);
     }
 
+    /**
+     * The URI setter.
+     *
+     * @param uris Optional. A JSON array of the Spotify track URIs to play.
+     * @return A {@link StartResumeUsersPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder uris(final JsonArray uris) {
       assert (uris != null);
       assert (!uris.isJsonNull());
       return setBodyParameter("uris", uris);
     }
 
+    /**
+     * The offset setter.
+     * <p>
+     * <b>Note:</b> If {@link #context_uri(String)} has been set and corresponds to an album or playlist object, an
+     * offset can be specified either by track {@code uri} OR {@code position}. If both are present the request will
+     * return an error. If incorrect values are provided for {@code position} or {@code uri}, the request may be
+     * accepted but with an unpredictable resulting action on playback.
+     *
+     * @param offset Optional. Indicates from where in the context playback should start. Only available when
+     *               {@link #context_uri(String)} corresponds to an album or playlist object, or when the
+     *               {@link #uris(JsonArray)} parameter is used. <br> The {@code position} parameter in the
+     *               {@code offset} object is zero based and can’t be negative. <br> The {@code uri} parameter in the
+     *               {@code offset} object is a string representing the URI of the item to start at.
+     * @return A {@link StartResumeUsersPlaybackRequest.Builder}.
+     */
     public Builder offset(final JsonObject offset) {
       assert (offset != null);
       assert (!offset.isJsonNull());
       return setBodyParameter("offset", offset);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link StartResumeUsersPlaybackRequest}.
+     */
     @Override
     public StartResumeUsersPlaybackRequest build() {
       setPath("/v1/me/player/play");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/ToggleShuffleForUsersPlaybackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/ToggleShuffleForUsersPlaybackRequest.java
@@ -5,12 +5,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Toggle shuffle on or off for user’s playback.
+ */
 public class ToggleShuffleForUsersPlaybackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link ToggleShuffleForUsersPlaybackRequest} constructor.
+   *
+   * @param builder A {@link ToggleShuffleForUsersPlaybackRequest.Builder}.
+   */
   private ToggleShuffleForUsersPlaybackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Toggle the shuffle state of an user's playback.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,22 +33,52 @@ public class ToggleShuffleForUsersPlaybackRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link ToggleShuffleForUsersPlaybackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link ToggleShuffleForUsersPlaybackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The toggle state setter.
+     *
+     * @param state Required. {@code true}: Shuffle user's playback. {@code false}: Do not shuffle user's playback.
+     * @return A {@link ToggleShuffleForUsersPlaybackRequest.Builder}.
+     */
     public Builder state(final Boolean state) {
       return setQueryParameter("state", state);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link ToggleShuffleForUsersPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_id(final String device_id) {
       assert (device_id != null);
       assert (!device_id.equals(""));
       return setQueryParameter("device_id", device_id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link ToggleShuffleForUsersPlaybackRequest}.
+     */
     @Override
     public ToggleShuffleForUsersPlaybackRequest build() {
       setPath("/v1/me/player/shuffle");

--- a/src/main/java/com/wrapper/spotify/requests/data/player/TransferUsersPlaybackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/TransferUsersPlaybackRequest.java
@@ -6,12 +6,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Transfer playback to a new device and determine if it should start playing.
+ */
 public class TransferUsersPlaybackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link TransferUsersPlaybackRequest} constructor.
+   *
+   * @param builder A {@link TransferUsersPlaybackRequest.Builder}.
+   */
   private TransferUsersPlaybackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Transfer playback to a new device.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -19,22 +34,54 @@ public class TransferUsersPlaybackRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link TransferUsersPlaybackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link TransferUsersPlaybackRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The device ID setter.
+     *
+     * @param device_ids Required. A JSON array containing the ID of the device on which playback should be
+     *                   started/transferred. <b>Note:</b> Although an array is accepted, only a single
+     *                   {@code device_id} is currently supported.
+     * @return A {@link TransferUsersPlaybackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder device_ids(final JsonArray device_ids) {
       assert (device_ids != null);
       assert (!device_ids.isJsonNull());
       return setBodyParameter("device_ids", device_ids);
     }
 
+    /**
+     * The playing state setter.
+     *
+     * @param play Optional. {@code true}: ensure playback happens on new device.
+     *             {@code false} or not provided: keep the current playback state.
+     * @return A {@link TransferUsersPlaybackRequest.Builder}.
+     */
     public Builder play(final Boolean play) {
       return setBodyParameter("play", play);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link TransferUsersPlaybackRequest}.
+     */
     @Override
     public TransferUsersPlaybackRequest build() {
       setPath("/v1/me/player");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/AddTracksToPlaylistRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/AddTracksToPlaylistRequest.java
@@ -7,12 +7,32 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Add one or more tracks to a user’s playlist.
+ * <p>
+ * Use this endpoint to add Spotify tracks to a user’s playlist, sending their Spotify URI.
+ * Note that local tracks can’t be added.
+ */
 public class AddTracksToPlaylistRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link AddTracksToPlaylistRequest} constructor.
+   *
+   * @param builder A {@link AddTracksToPlaylistRequest.Builder}.
+   */
   private AddTracksToPlaylistRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Add tracks to playlist.
+   *
+   * @return A playlist snapshot ID. The snapshot ID can be used to identify your playlist version in future requests.
+   * @see <a href="https://developer.spotify.com/web-api/working-with-playlists/#version-control-and-snapshots">
+   *      Spotify: Version Control and Snapshots</a>
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public SnapshotResult execute() throws
           IOException,
@@ -20,34 +40,88 @@ public class AddTracksToPlaylistRequest extends AbstractDataRequest {
     return new SnapshotResult.JsonUtil().createModelObject(postJson());
   }
 
+  /**
+   * Builder class for building an {@link AddTracksToPlaylistRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link AddTracksToPlaylistRequest.Builder}.
+     * <p>
+     * Adding tracks to the current user's public playlists requires authorization of the {@code playlist-modify-public}
+     * scope; adding tracks to the current user's private playlist (including collaborative playlists) requires the
+     * {@code playlist-modify-private} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return An {@link AddTracksToPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return An {@link AddTracksToPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The track URIs setter.
+     * <p>
+     * <b>Note:</b> It is likely that passing a large number of track URIs as a query parameter will exceed the maximum
+     * length of the request URI. When adding a large number of tracks it is recommended to pass them
+     * with {@link #uris(JsonArray)}.
+     *
+     * @param uris Optional. A comma-separated list of Spotify track URIs to add. Maximum: 100 track URIs.
+     * @return An {@link AddTracksToPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder uris(final String uris) {
       assert (uris != null);
       assert (!uris.equals(""));
       return setQueryParameter("uris", uris);
     }
 
+    /**
+     * The position setter.
+     *
+     * @param position Optional. The position to insert the tracks, a zero-based index. If omitted, the
+     *                 tracks will be appended to the playlist. Tracks are added in the order they are
+     *                 listed in the query string or request body.
+     * @return An {@link AddTracksToPlaylistRequest.Builder}.
+     */
     public Builder position(final Integer position) {
       return position(position, false);
     }
 
+    /**
+     * The track URIs setter.
+     * <p>
+     * <b>Note:</b> If the URIs already have been set with {@link #uris(String)}, any URIs listed here will be ignored.
+     * @param uris Optional. A JSON array of the Spotify track URIs to add. maximum: 100 track URIs.
+     * @return An {@link AddTracksToPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder uris(final JsonArray uris) {
       assert (uris != null);
       assert (!uris.isJsonNull());
@@ -55,6 +129,16 @@ public class AddTracksToPlaylistRequest extends AbstractDataRequest {
       return setBodyParameter("uris", uris);
     }
 
+    /**
+     * The position setter. You can set it in the request query string or request body, depending on the
+     * {@code use_body} parameter.
+     *
+     * @param position Optional. The position to insert the tracks, a zero-based index. If omitted, the
+     *                 tracks will be appended to the playlist. Tracks are added in the order they are
+     *                 listed in the query string or request body.
+     * @param use_body Whether to include the position in the request query string or body.
+     * @return An {@link AddTracksToPlaylistRequest.Builder}.
+     */
     public Builder position(final Integer position, final Boolean use_body) {
       assert (position >= 0);
 
@@ -65,6 +149,11 @@ public class AddTracksToPlaylistRequest extends AbstractDataRequest {
       }
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link AddTracksToPlaylistRequest}.
+     */
     @Override
     public AddTracksToPlaylistRequest build() {
       setHeader("Content-Type", "application/json");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/ChangePlaylistsDetailsRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/ChangePlaylistsDetailsRequest.java
@@ -5,12 +5,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Change a playlist’s name and public/private state. (The user must, of course, own the playlist.)
+ */
 public class ChangePlaylistsDetailsRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link ChangePlaylistsDetailsRequest} constructor.
+   *
+   * @param builder A {@link ChangePlaylistsDetailsRequest.Builder}.
+   */
   private ChangePlaylistsDetailsRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Change a playlist's details.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,44 +33,102 @@ public class ChangePlaylistsDetailsRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link ChangePlaylistsDetailsRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link ChangePlaylistsDetailsRequest.Builder}.
+     * <p>
+     * Modifying an user's public playlists requires authorization of the {@code playlist-modify-public}
+     * scope; Modifying an user's private playlist (including collaborative playlists) requires the
+     * {@code playlist-modify-private} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link ChangePlaylistsDetailsRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return A {@link ChangePlaylistsDetailsRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The playlist name setter.
+     *
+     * @param name Optional. The new name for the playlist.
+     * @return A {@link ChangePlaylistsDetailsRequest.Builder}.
+     */
     public Builder name(final String name) {
       assert (name != null);
       assert (!name.equals(""));
       return setBodyParameter("name", name);
     }
 
+    /**
+     * The public status setter.
+     *
+     * @param public_ Optional. If {@code true} the playlist will be public, if {@code false} it will be private.
+     * @return A {@link ChangePlaylistsDetailsRequest.Builder}.
+     */
     public Builder public_(final Boolean public_) {
       return setBodyParameter("public", public_);
     }
 
+    /**
+     * The collaborative state setter.
+     *
+     * @param collaborative Optional. If {@code true}, the playlist will become collaborative and other users will be
+     *                      able to modify the playlist in their Spotify client. <b>Note:</b> You can only set
+     *                      {@link #collaborative(Boolean)} to {@code true} on non-public playlists.
+     * @return A {@link ChangePlaylistsDetailsRequest.Builder}.
+     */
     public Builder collaborative(final Boolean collaborative) {
       return setBodyParameter("collaborative", collaborative);
     }
 
+    /**
+     * The playlist description setter.
+     *
+     * @param description Optional, value for playlist description as displayed in Spotify Clients and in the Web API.
+     * @return A {@link ChangePlaylistsDetailsRequest.Builder}.
+     */
     public Builder description(final String description) {
       assert (description != null);
       assert (!description.equals(""));
       return setBodyParameter("description", description);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link ChangePlaylistsDetailsRequest}.
+     */
     @Override
     public ChangePlaylistsDetailsRequest build() {
       setHeader("Content-Type", "application/json");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/CreatePlaylistRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/CreatePlaylistRequest.java
@@ -6,12 +6,28 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Create a playlist for a Spotify user. (The playlist will be empty until you add tracks
+ * with an {@link AddTracksToPlaylistRequest}.)
+ */
 public class CreatePlaylistRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link CreatePlaylistRequest} constructor.
+   *
+   * @param builder A {@link CreatePlaylistRequest.Builder}.
+   */
   private CreatePlaylistRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Create a new playlist.
+   *
+   * @return The newly created {@link Playlist}.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Playlist execute() throws
           IOException,
@@ -19,38 +35,93 @@ public class CreatePlaylistRequest extends AbstractDataRequest {
     return new Playlist.JsonUtil().createModelObject(postJson());
   }
 
+  /**
+   * Builder class for building a {@link CreatePlaylistRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link CreatePlaylistRequest.Builder}.
+     * <p>
+     * Creating a public playlists requires authorization of the {@code playlist-modify-public}
+     * scope; Creating a private playlist requires the {@code playlist-modify-private} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link CreatePlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist name setter.
+     *
+     * @param name Optional. The name for the playlist. This name does not need
+     *             to be unique; a user may have several playlists with the same name.
+     * @return A {@link CreatePlaylistRequest.Builder}.
+     */
     public Builder name(final String name) {
       assert (name != null);
       assert (!name.equals(""));
       return setBodyParameter("name", name);
     }
 
+    /**
+     * The public status setter.
+     * <p>
+     * <b>Note:</b> To be able to create private playlists, the user must have
+     * granted the {@code playlist-modify-private} scope.
+     *
+     * @param public_ Optional. If {@code true} the playlist will be public, if {@code false} it will be private.
+     * @return A {@link CreatePlaylistRequest.Builder}.
+     */
     public Builder public_(final Boolean public_) {
       return setBodyParameter("public", public_);
     }
 
+    /**
+     * The collaborative state setter.
+     *
+     * @param collaborative Optional, default {@code false}. If {@code true} the playlist will be collaborative.
+     *                      <b>Note:</b> To create a collaborative playlist you must also set {@link #public_(Boolean)}
+     *                      to {@code false}. To create collaborative playlists you must have granted
+     *                     {@code playlist-modify-private} and {@code playlist-modify-public} scopes.
+     * @return A {@link CreatePlaylistRequest.Builder}.
+     */
     public Builder collaborative(final Boolean collaborative) {
       return setBodyParameter("collaborative", collaborative);
     }
 
+    /**
+     * The playlist description setter.
+     *
+     * @param description Optional, value for playlist description as displayed in Spotify Clients and in the Web API.
+     * @return A {@link CreatePlaylistRequest.Builder}.
+     */
     public Builder description(final String description) {
       assert (description != null);
       assert (!description.equals(""));
       return setBodyParameter("description", description);
     }
 
+    /**
+     * the request build method.
+     *
+     * @return A custom {@link CreatePlaylistRequest}.
+     */
     @Override
     public CreatePlaylistRequest build() {
       setHeader("Content-Type", "application/json");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/GetListOfCurrentUsersPlaylistsRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/GetListOfCurrentUsersPlaylistsRequest.java
@@ -7,12 +7,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get a list of the playlists owned or followed by the current Spotify user.
+ */
 public class GetListOfCurrentUsersPlaylistsRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetListOfCurrentUsersPlaylistsRequest} constructor.
+   *
+   * @param builder A {@link GetListOfCurrentUsersPlaylistsRequest.Builder}.
+   */
   private GetListOfCurrentUsersPlaylistsRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get a list of the current user's playlists.
+   *
+   * @return A {@link PlaylistSimplified} paging.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Paging<PlaylistSimplified> execute() throws
           IOException,
@@ -20,22 +35,56 @@ public class GetListOfCurrentUsersPlaylistsRequest extends AbstractDataRequest {
     return new PlaylistSimplified.JsonUtil().createModelObjectPaging(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetListOfCurrentUsersPlaylistsRequest}
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetListOfCurrentUsersPlaylistsRequest.Builder}.
+     * <p>
+     * Private playlists are only retrievable for the current user and requires the {@code playlist-read-private}
+     * scope to have been authorized by the user. <b>Note:</b> This scope alone will not return collaborative playlists,
+     * even though they are always private.
+     * <p>
+     * Collaborative playlists are only retrievable for the current user and requires the
+     * {@code playlist-read-collaborative} scope to have been authorized by the user.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of playlists to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link GetListOfCurrentUsersPlaylistsRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (1 <= limit && limit <= 50);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first playlist to return. Default: 0 (the first object). Maximum offset:
+     *              100.000. Use with {@link #limit(Integer)} to get the next set of playlists.
+     * @return A {@link GetListOfCurrentUsersPlaylistsRequest.Builder}.
+     */
     public Builder offset(final Integer offset) {
       assert (0 <= offset && offset <= 100000);
       return setQueryParameter("offset", offset);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetListOfCurrentUsersPlaylistsRequest}.
+     */
     @Override
     public GetListOfCurrentUsersPlaylistsRequest build() {
       setPath("/v1/me/playlists");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/GetListOfUsersPlaylistsRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/GetListOfUsersPlaylistsRequest.java
@@ -7,12 +7,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get a list of the playlists owned or followed by a Spotify user.
+ */
 public class GetListOfUsersPlaylistsRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetListOfUsersPlaylistsRequest} constructor.
+   *
+   * @param builder A {@link GetListOfUsersPlaylistsRequest.Builder}.
+   */
   private GetListOfUsersPlaylistsRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get an user's playlists.
+   *
+   * @return A {@link PlaylistSimplified} paging.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Paging<PlaylistSimplified> execute() throws
           IOException,
@@ -20,28 +35,69 @@ public class GetListOfUsersPlaylistsRequest extends AbstractDataRequest {
     return new PlaylistSimplified.JsonUtil().createModelObjectPaging(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetListOfUsersPlaylistsRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetListOfUsersPlaylistsRequest.Builder}.
+     * <p>
+     * Private playlists are only retrievable for the current user and requires the {@code playlist-read-private}
+     * scope to have been authorized by the user. <b>Note:</b> This scope alone will not return collaborative playlists,
+     * even though they are always private.
+     * <p>
+     * Collaborative playlists are only retrievable for the current user and requires the
+     * {@code playlist-read-collaborative} scope to have been authorized by the user.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link GetListOfUsersPlaylistsRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of playlists to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link GetListOfUsersPlaylistsRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (1 <= limit && limit <= 50);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first playlist to return. Default: 0 (the first object). Maximum offset:
+     *              100.000. Use with {@link #limit(Integer)} to get the next set of playlists.
+     * @return A {@link GetListOfUsersPlaylistsRequest.Builder}.
+     */
     public Builder offset(final Integer offset) {
       assert (0 <= offset && offset <= 100000);
       return setQueryParameter("offset", offset);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetListOfUsersPlaylistsRequest}.
+     */
     @Override
     public GetListOfUsersPlaylistsRequest build() {
       setPath("/v1/users/{user_id}/playlists");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/GetPlaylistCoverImageRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/GetPlaylistCoverImageRequest.java
@@ -6,36 +6,78 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get the current image associated with a specific playlist.
+ */
 public class GetPlaylistCoverImageRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetPlaylistCoverImageRequest} constructor.
+   *
+   * @param builder A {@link GetPlaylistCoverImageRequest.Builder}.
+   */
   private GetPlaylistCoverImageRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get the cover image of a playlist.
+   *
+   * @return Multiple {@link Image} objects.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   public Image[] execute() throws
           IOException,
           SpotifyWebApiException {
     return new Image.JsonUtil().createModelObjectArray(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetPlaylistCoverImageRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetPlaylistCoverImageRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link GetPlaylistCoverImageRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return A {@link GetPlaylistCoverImageRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetPlaylistCoverImageRequest}.
+     */
     @Override
     public GetPlaylistCoverImageRequest build() {
       setPath("/v1/users/{user_id}/playlists/{playlist_id}/images");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/GetPlaylistRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/GetPlaylistRequest.java
@@ -7,12 +7,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get a playlist owned by a Spotify user.
+ */
 public class GetPlaylistRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetPlaylistRequest} constructor.
+   *
+   * @param builder A {@link GetPlaylistRequest.Builder}.
+   */
   private GetPlaylistRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get a playlist.
+   *
+   * @return A {@link Playlist}.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Playlist execute() throws
           IOException,
@@ -20,35 +35,82 @@ public class GetPlaylistRequest extends AbstractDataRequest {
     return new Playlist.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetPlaylistRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetPlaylistRequest.Builder}.
+     * <p>
+     * Both Public and Private playlists belonging to any user are retrievable on provision of a valid access token.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link GetPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return A {@link GetPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The fields filter setter.
+     *
+     * @param fields Optional. Filters for the query: a comma-separated list of the fields to return.
+     *               If omitted, all fields are returned.
+     * @return A {@link GetPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/get-playlist/#tablepress-101">
+     *      Spotify: More Details on Playlist Fields</a>
+     */
     public Builder fields(final String fields) {
       assert (fields != null);
       assert (!fields.equals(""));
       return setQueryParameter("fields", fields);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. Provide this
+     *               parameter if you want to apply Track Relinking.
+     * @return A {@link GetPlaylistRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     * @see <a href="https://developer.spotify.com/web-api/track-relinking-guide/">Spotify: Track Relinking Guide</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * ther request build method.
+     *
+     * @return A custom {@link GetPlaylistRequest}.
+     */
     @Override
     public GetPlaylistRequest build() {
       setPath("/v1/users/{user_id}/playlists/{playlist_id}");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/GetPlaylistsTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/GetPlaylistsTracksRequest.java
@@ -8,12 +8,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get full details of the tracks of a playlist owned by a Spotify user.
+ */
 public class GetPlaylistsTracksRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetPlaylistsTracksRequest} constructor.
+   *
+   * @param builder A {@link GetPlaylistsTracksRequest.Builder}.
+   */
   private GetPlaylistsTracksRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get a playlist's tracks.
+   *
+   * @return A playlist's tracks.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Paging<PlaylistTrack> execute() throws
           IOException,
@@ -21,45 +36,104 @@ public class GetPlaylistsTracksRequest extends AbstractDataRequest {
     return new PlaylistTrack.JsonUtil().createModelObjectPaging(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetPlaylistsTracksRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetPlaylistsTracksRequest.Builder}.
+     * <p>
+     * Both Public and Private playlists belonging to any user are retrievable on provision of a valid access token.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link GetPlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return A {@link GetPlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The fields filter setter.
+     *
+     * @param fields Optional. Filters for the query: a comma-separated list of the fields to return.
+     *               If omitted, all fields are returned.
+     * @return A {@link GetPlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/get-playlists-tracks/#tablepress-107">
+     *      Spotify: More Details on Playlist Fields</a>
+     */
     public Builder fields(final String fields) {
       assert (fields != null);
       assert (!fields.equals(""));
       return setQueryParameter("fields", fields);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of tracks to return. Default: 100. Minimum: 1. Maximum: 100.
+     * @return A {@link GetPlaylistsTracksRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (1 <= limit && limit <= 100);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first track to return. Default: 0 (the first object).
+     * @return A {@link GetPlaylistsTracksRequest.Builder}.
+     */
     public Builder offset(final Integer offset) {
       assert (offset >= 0);
       return setQueryParameter("offset", offset);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. Provide this
+     *               parameter if you want to apply Track Relinking.
+     * @return A {@link GetPlaylistsTracksRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     * @see <a href="https://developer.spotify.com/web-api/track-relinking-guide/">Spotify: Track Relinking Guide</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetPlaylistsTracksRequest}.
+     */
     @Override
     public GetPlaylistsTracksRequest build() {
       setPath("/v1/users/{user_id}/playlists/{playlist_id}/tracks");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequest.java
@@ -7,12 +7,29 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Remove one or more tracks from a user’s playlist.
+ */
 public class RemoveTracksFromPlaylistRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link RemoveTracksFromPlaylistRequest} constructor.
+   *
+   * @param builder A {@link RemoveTracksFromPlaylistRequest.Builder}.
+   */
   private RemoveTracksFromPlaylistRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Remove tracks from a playlist.
+   *
+   * @return A playlist snapshot ID. The snapshot ID can be used to identify your playlist version in future requests.
+   * @see <a href="https://developer.spotify.com/web-api/working-with-playlists/#version-control-and-snapshots">
+   *      Spotify: Version Control and Snapshots</a>
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public SnapshotResult execute() throws
           IOException,
@@ -20,36 +37,98 @@ public class RemoveTracksFromPlaylistRequest extends AbstractDataRequest {
     return new SnapshotResult.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link RemoveTracksFromPlaylistRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link RemoveTracksFromPlaylistRequest.Builder}.
+     * <p>
+     * Removing tracks from an user's public playlists requires authorization of the {@code playlist-modify-public}
+     * scope; removing tracks from an user's private playlist (including collaborative playlists) requires the
+     * {@code playlist-modify-private} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return An {@link RemoveTracksFromPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return An {@link RemoveTracksFromPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The track URIs setter.
+     * <p>
+     * There are several ways to specify which tracks to remove, determined by the request parameters.
+     * Removing all occurrences of specific tracks: <br>
+     * {@code { "tracks": [{ "uri": "spotify:track:4iV5W9uYEdYUVa79Axb7Rh" },
+     * {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M" }] }} <br>
+     * Removing a specific occurrence of a track: <br>
+     * {@code { "tracks": [{ "uri": "spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "positions": [0,3] },
+     * { "uri": "spotify:track:1301WleyT98MSxVHPZCA6M", "positions": [7] }] }}
+     *
+     * @param tracks Required. An array of objects containing Spotify URIs of the tracks to remove.
+     * @return A {@link RemoveTracksFromPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder tracks(final JsonArray tracks) {
       assert (tracks != null);
       assert (!tracks.isJsonNull());
       return setBodyParameter("tracks", tracks);
     }
 
+    /**
+     * The playlist snapshot ID setter.
+     * <p>
+     * To guard against errors when concurrent edits happen to the same playlist, we recommend specifying a snapshot ID.
+     * The snapshot ID lets us know which version of the playlist you are trying to edit. Concurrent edits by another
+     * user will be automatically resolved. If a given track in a given position is not found in the specified snapshot,
+     * the entire request will fail an no edits will take place.
+     *
+     * @param snapshotId Optional. The playlist's snapshot ID against which you want to make the changes. The API will
+     *                   validate that the specified tracks exist and in the specified positions and make the changes,
+     *                   even if more recent changes have been made to the playlist.
+     * @return A {@link RemoveTracksFromPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/working-with-playlists/#version-control-and-snapshots">
+     *      Spotify: Version Control and Snapshots</a>
+     */
     public Builder snapshotId(final String snapshotId) {
       assert (snapshotId != null);
       assert (!snapshotId.equals(""));
       return setBodyParameter("snapshot_id", snapshotId);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link RemoveTracksFromPlaylistRequest}.
+     */
     @Override
     public RemoveTracksFromPlaylistRequest build() {
       setHeader("Content-Type", "application/json");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/ReorderPlaylistsTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/ReorderPlaylistsTracksRequest.java
@@ -6,12 +6,33 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Reorder a track or a group of tracks in a playlist.
+ * <p>
+ * When reordering tracks, the timestamp indicating when they were added and the user who added them will
+ * be kept untouched. In addition, the users following the playlists won’t be notified about changes in
+ * the playlists when the tracks are reordered.
+ */
 public class ReorderPlaylistsTracksRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link ReorderPlaylistsTracksRequest} constructor.
+   *
+   * @param builder A {@link ReorderPlaylistsTracksRequest.Builder}.
+   */
   private ReorderPlaylistsTracksRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Reorder the tracks in a playlist.
+   *
+   * @return A playlist snapshot ID. The snapshot ID can be used to identify your playlist version in future requests.
+   * @see <a href="https://developer.spotify.com/web-api/working-with-playlists/#version-control-and-snapshots">
+   *      Spotify: Version Control and Snapshots</a>
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public SnapshotResult execute() throws
           IOException,
@@ -19,48 +40,107 @@ public class ReorderPlaylistsTracksRequest extends AbstractDataRequest {
     return new SnapshotResult.JsonUtil().createModelObject(putJson());
   }
 
+  /**
+   * Builder class for building a {@link ReorderPlaylistsTracksRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link ReorderPlaylistsTracksRequest.Builder}.
+     * <p>
+     * Reordering tracks in the current user's public playlists requires authorization of the
+     * {@code playlist-modify-public} scope; reordering tracks in the current user's private playlist (including
+     * collaborative playlists) requires the {@code playlist-modify-private} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link ReorderPlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return A {@link ReorderPlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The range start setter.
+     *
+     * @param range_start Required. The position of the first track to be reordered.
+     * @return A {@link ReorderPlaylistsTracksRequest.Builder}.
+     */
     public Builder range_start(final Integer range_start) {
       assert (range_start != null);
       assert (range_start >= 0);
       return setBodyParameter("range_start", range_start);
     }
 
+    /**
+     * The range length setter.
+     *
+     * @param range_length 	Optional. The amount of tracks to be reordered. Defaults to 1 if not set.
+     * @return A {@link ReorderPlaylistsTracksRequest.Builder}.
+     */
     public Builder range_length(final Integer range_length) {
       assert (range_length != null);
       assert (range_length >= 1);
       return setBodyParameter("range_length", range_length);
     }
 
+    /**
+     * The insert before setter.
+     *
+     * @param insert_before Required. The position where the tracks should be inserted. To reorder the tracks to the
+     *                      end of the playlist, simply set insert_before to the position after the last track.
+     * @return A {@link ReorderPlaylistsTracksRequest.Builder}.
+     */
     public Builder insert_before(final Integer insert_before) {
       assert (insert_before != null);
       assert (insert_before >= 0);
       return setBodyParameter("insert_before", insert_before);
     }
 
+    /**
+     * The playlist snapshot ID setter.
+     *
+     * @param snapshotId Optional. The playlist's snapshot ID against which you want to make the changes.
+     * @return A {@link RemoveTracksFromPlaylistRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/working-with-playlists/#version-control-and-snapshots">
+     *      Spotify: Version Control and Snapshots</a>
+     */
     public Builder snapshot_id(final String snapshot_id) {
       assert (snapshot_id != null);
       assert (!snapshot_id.equals(""));
       return setBodyParameter("snapshot_id", snapshot_id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link ReorderPlaylistsTracksRequest}.
+     */
     @Override
     public ReorderPlaylistsTracksRequest build() {
       setPath("/v1/users/{user_id}/playlists/{playlist_id}/tracks");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/ReorderPlaylistsTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/ReorderPlaylistsTracksRequest.java
@@ -125,7 +125,7 @@ public class ReorderPlaylistsTracksRequest extends AbstractDataRequest {
     /**
      * The playlist snapshot ID setter.
      *
-     * @param snapshotId Optional. The playlist's snapshot ID against which you want to make the changes.
+     * @param snapshot_id Optional. The playlist's snapshot ID against which you want to make the changes.
      * @return A {@link RemoveTracksFromPlaylistRequest.Builder}.
      * @see <a href="https://developer.spotify.com/web-api/working-with-playlists/#version-control-and-snapshots">
      *      Spotify: Version Control and Snapshots</a>

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/ReplacePlaylistsTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/ReplacePlaylistsTracksRequest.java
@@ -6,12 +6,28 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Replace all the tracks in a playlist, overwriting its existing tracks. This powerful request can be useful for
+ * replacing tracks, re-ordering existing tracks, or clearing the playlist.
+ */
 public class ReplacePlaylistsTracksRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link ReplacePlaylistsTracksRequest} constructor.
+   *
+   * @param builder A {@link ReplacePlaylistsTracksRequest.Builder}.
+   */
   private ReplacePlaylistsTracksRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Replace tracks in a playlist.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -19,30 +35,73 @@ public class ReplacePlaylistsTracksRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building a {@link ReplacePlaylistsTracksRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link ReplacePlaylistsTracksRequest.Builder}.
+     * <p>
+     * Replacing tracks in the current user's public playlists requires authorization of the
+     * {@code playlist-modify-public} scope; replacing tracks in the current user's private playlist (including
+     * collaborative playlists) requires the {@code playlist-modify-private} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link ReplacePlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return A {@link ReplacePlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The track URIs setter.
+     *
+     * @param uris Optional. A comma-separated list of Spotify track URIs to set. Maximum: 100 track URIs.
+     * @return A {@link ReplacePlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder uris(final String uris) {
       assert (uris != null);
       assert (!uris.equals(""));
       return setQueryParameter("uris", uris);
     }
 
+    /**
+     * The track URIs setter.
+     * <p>
+     * <b>Note:</b> If the URIs have already been set with {@link #uris(String)}, any URIs set here will be ignored.
+     *
+     * @param uris Optional. A JSON array of Spotify track URIs to set. Maximum: 100 track URIs.
+     * @return A {@link ReplacePlaylistsTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder uris(final JsonArray uris) {
       assert (uris != null);
       assert (!uris.isJsonNull());
@@ -50,6 +109,11 @@ public class ReplacePlaylistsTracksRequest extends AbstractDataRequest {
       return setBodyParameter("uris", uris);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link ReplacePlaylistsTracksRequest}.
+     */
     @Override
     public ReplacePlaylistsTracksRequest build() {
       setHeader("Content-Type", "application/json");

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/UploadCustomPlaylistCoverImageRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/UploadCustomPlaylistCoverImageRequest.java
@@ -5,12 +5,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Replace the image used to represent a specific playlist.
+ */
 public class UploadCustomPlaylistCoverImageRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link UploadCustomPlaylistCoverImageRequest} constructor.
+   *
+   * @param builder A {@link UploadCustomPlaylistCoverImageRequest.Builder}.
+   */
   private UploadCustomPlaylistCoverImageRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Upload a new playlist image.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public String execute() throws
           IOException,
@@ -18,24 +33,57 @@ public class UploadCustomPlaylistCoverImageRequest extends AbstractDataRequest {
     return putJson();
   }
 
+  /**
+   * Builder class for building an {@link UploadCustomPlaylistCoverImageRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link UploadCustomPlaylistCoverImageRequest.Builder}.
+     * <p>
+     * This access token must be tied to the user who owns the playlist, and must have the scope
+     * {@code ugc-image-upload} granted. In addition, the token must also contain {@code playlist-modify-public}
+     * and/or {@code playlist-modify-private}, depending the public status of the playlist you want to update.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link UploadCustomPlaylistCoverImageRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The playlist ID setter.
+     *
+     * @param playlist_id The Spotify ID for the playlist.
+     * @return A {@link UploadCustomPlaylistCoverImageRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder playlist_id(final String playlist_id) {
       assert (playlist_id != null);
       assert (!playlist_id.equals(""));
       return setPathParameter("playlist_id", playlist_id);
     }
 
+    /**
+     * The image data setter.
+     *
+     * @param image_data Base64 encoded JPEG image data, maximum payload size is 256 KB.
+     * @return A {@link UploadCustomPlaylistCoverImageRequest.Builder}.
+     */
     public Builder image_data(final String image_data) {
       assert (image_data != null);
       assert (!image_data.equals(""));
@@ -43,6 +91,11 @@ public class UploadCustomPlaylistCoverImageRequest extends AbstractDataRequest {
       return setBody(image_data);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link UploadCustomPlaylistCoverImageRequest}.
+     */
     @Override
     public UploadCustomPlaylistCoverImageRequest build() {
       setPath("/v1/users/{user_id}/playlists/{playlist_id}/images");

--- a/src/main/java/com/wrapper/spotify/requests/data/search/SearchItemRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/search/SearchItemRequest.java
@@ -7,12 +7,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get Spotify catalog information about artists, albums, tracks or playlists that match a keyword string.
+ */
 public class SearchItemRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SearchItemRequest} constructor.
+   *
+   * @param builder A {@link SearchItemRequest.Builder}.
+   */
   private SearchItemRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Search for an item.
+   *
+   * @return A {@link SearchResult}.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public SearchResult execute() throws
           IOException,
@@ -20,41 +35,90 @@ public class SearchItemRequest extends AbstractDataRequest {
     return new SearchResult.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link SearchItemRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SearchItemRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The search query setter.
+     *
+     * @param q Required. The search query's keywords (and optional field filters and operators).
+     * @return A {@link SearchItemRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/search-item/#tablepress-47">Spotify: Search Query Options</a>
+     */
     public Builder q(final String q) {
       assert (q != null);
       assert (!q.equals(""));
       return setQueryParameter("q", q);
     }
 
+    /**
+     * The type setter.
+     *
+     * @param type Required. A comma-separated list of item types to search across. Valid types are: {@code album},
+     *             {@code artist}, {@code playlist}, and {@code track}.
+     * @return A {@link SearchItemRequest.Builder}.
+     */
     public Builder type(final String type) {
       assert (type != null);
       assert (type.matches("((^|,)(album|artist|playlist|track))+$"));
       return setQueryParameter("type", type);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. If a country code is given, only artists,
+     *               albums, and tracks with content playable in that market will be returned. (Playlist
+     *               results are not affected by the market parameter.)
+     * @return A {@link SearchItemRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of results to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link SearchItemRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (limit != null);
       assert (1 <= limit && limit <= 50);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first result to return. Default: 0 (i.e., the first result). Maximum
+     *               offset: 100.000. Use with {@link #limit(Integer)} to get the next page of search results.
+     * @return A {@link SearchItemRequest.Builder}.
+     */
     public Builder offset(final Integer offset) {
       assert (offset != null);
       assert (0 <= offset && offset <= 100000);
       return setQueryParameter("offset", offset);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A {@link SearchItemRequest.Builder}.
+     */
     @Override
     public SearchItemRequest build() {
       setPath("/v1/search");

--- a/src/main/java/com/wrapper/spotify/requests/data/search/simplified/SearchAlbumsRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/search/simplified/SearchAlbumsRequest.java
@@ -8,12 +8,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get Spotify catalog information about albums that match a keyword string.
+ */
 public class SearchAlbumsRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SearchAlbumsRequest} constructor.
+   *
+   * @param builder A {@link SearchAlbumsRequest.Builder}.
+   */
   private SearchAlbumsRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Search for albums.
+   *
+   * @return An {@link AlbumSimplified} paging.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Paging<AlbumSimplified> execute() throws
           IOException,
@@ -21,35 +36,77 @@ public class SearchAlbumsRequest extends AbstractDataRequest {
     return new AlbumSimplified.JsonUtil().createModelObjectPaging(getJson(), "albums");
   }
 
+  /**
+   * Builder class for building a {@link SearchAlbumsRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SearchAlbumsRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The search query setter.
+     *
+     * @param q Required. The search query's keywords (and optional field filters and operators).
+     * @return A {@link SearchAlbumsRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/search-item/#tablepress-47">Spotify: Search Query Options</a>
+     */
     public Builder q(final String q) {
       assert (q != null);
       assert (!q.equals(""));
       return setQueryParameter("q", q);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. If a country code is given, only artists,
+     *               albums, and tracks with content playable in that market will be returned. (Playlist
+     *               results are not affected by the market parameter.)
+     * @return A {@link SearchAlbumsRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of results to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link SearchAlbumsRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (limit != null);
       assert (1 <= limit && limit <= 50);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first result to return. Default: 0 (i.e., the first result). Maximum
+     *               offset: 100.000. Use with {@link #limit(Integer)} to get the next page of search results.
+     * @return A {@link SearchAlbumsRequest.Builder}.
+     */
     public Builder offset(final Integer offset) {
       assert (offset != null);
       assert (0 <= offset && offset <= 100000);
       return setQueryParameter("offset", offset);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A {@link SearchAlbumsRequest.Builder}.
+     */
     @Override
     public SearchAlbumsRequest build() {
       setPath("/v1/search");

--- a/src/main/java/com/wrapper/spotify/requests/data/search/simplified/SearchArtistsRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/search/simplified/SearchArtistsRequest.java
@@ -8,12 +8,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get Spotify catalog information about artists that match a keyword string.
+ */
 public class SearchArtistsRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SearchArtistsRequest} constructor.
+   *
+   * @param builder A {@link SearchArtistsRequest.Builder}.
+   */
   private SearchArtistsRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Search for artists.
+   *
+   * @return An {@link Artist} paging.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Paging<Artist> execute() throws
           IOException,
@@ -21,35 +36,77 @@ public class SearchArtistsRequest extends AbstractDataRequest {
     return new Artist.JsonUtil().createModelObjectPaging(getJson(), "artists");
   }
 
+  /**
+   * Builder class for building a {@link SearchArtistsRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SearchArtistsRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The search query setter.
+     *
+     * @param q Required. The search query's keywords (and optional field filters and operators).
+     * @return A {@link SearchArtistsRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/search-item/#tablepress-47">Spotify: Search Query Options</a>
+     */
     public Builder q(final String q) {
       assert (q != null);
       assert (!q.equals(""));
       return setQueryParameter("q", q);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. If a country code is given, only artists,
+     *               albums, and tracks with content playable in that market will be returned. (Playlist
+     *               results are not affected by the market parameter.)
+     * @return A {@link SearchArtistsRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of results to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link SearchArtistsRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (limit != null);
       assert (1 <= limit && limit <= 50);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first result to return. Default: 0 (i.e., the first result). Maximum
+     *               offset: 100.000. Use with {@link #limit(Integer)} to get the next page of search results.
+     * @return A {@link SearchArtistsRequest.Builder}.
+     */
     public Builder offset(final Integer offset) {
       assert (offset != null);
       assert (0 <= offset && offset <= 100000);
       return setQueryParameter("offset", offset);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A {@link SearchArtistsRequest.Builder}.
+     */
     @Override
     public SearchArtistsRequest build() {
       setPath("/v1/search");

--- a/src/main/java/com/wrapper/spotify/requests/data/search/simplified/SearchPlaylistsRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/search/simplified/SearchPlaylistsRequest.java
@@ -8,12 +8,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get Spotify catalog information about playlists that match a keyword string.
+ */
 public class SearchPlaylistsRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SearchPlaylistsRequest} constructor.
+   *
+   * @param builder A {@link SearchPlaylistsRequest.Builder}.
+   */
   private SearchPlaylistsRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Search for playlists.
+   *
+   * @return A {@link PlaylistSimplified} paging.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Paging<PlaylistSimplified> execute() throws
           IOException,
@@ -21,35 +36,77 @@ public class SearchPlaylistsRequest extends AbstractDataRequest {
     return new PlaylistSimplified.JsonUtil().createModelObjectPaging(getJson(), "playlists");
   }
 
+  /**
+   * Builder class for building a {@link SearchPlaylistsRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SearchPlaylistsRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The search query setter.
+     *
+     * @param q Required. The search query's keywords (and optional field filters and operators).
+     * @return A {@link SearchPlaylistsRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/search-item/#tablepress-47">Spotify: Search Query Options</a>
+     */
     public Builder q(final String q) {
       assert (q != null);
       assert (!q.equals(""));
       return setQueryParameter("q", q);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. If a country code is given, only artists,
+     *               albums, and tracks with content playable in that market will be returned. (Playlist
+     *               results are not affected by the market parameter.)
+     * @return A {@link SearchPlaylistsRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of results to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link SearchPlaylistsRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (limit != null);
       assert (1 <= limit && limit <= 50);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first result to return. Default: 0 (i.e., the first result). Maximum
+     *               offset: 100.000. Use with {@link #limit(Integer)} to get the next page of search results.
+     * @return A {@link SearchPlaylistsRequest.Builder}.
+     */
     public Builder offset(final Integer offset) {
       assert (offset != null);
       assert (0 <= offset && offset <= 100000);
       return setQueryParameter("offset", offset);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A {@link SearchPlaylistsRequest.Builder}.
+     */
     @Override
     public SearchPlaylistsRequest build() {
       setPath("/v1/search");

--- a/src/main/java/com/wrapper/spotify/requests/data/search/simplified/SearchTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/search/simplified/SearchTracksRequest.java
@@ -8,12 +8,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get Spotify catalog information about tracks that match a keyword string.
+ */
 public class SearchTracksRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link SearchTracksRequest} constructor.
+   *
+   * @param builder A {@link SearchTracksRequest.Builder}.
+   */
   private SearchTracksRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Search for playlists.
+   *
+   * @return A {@link Track} paging.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Paging<Track> execute() throws
           IOException,
@@ -21,35 +36,77 @@ public class SearchTracksRequest extends AbstractDataRequest {
     return new Track.JsonUtil().createModelObjectPaging(getJson(), "tracks");
   }
 
+  /**
+   * Builder class for building a {@link SearchTracksRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link SearchTracksRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The search query setter.
+     *
+     * @param q Required. The search query's keywords (and optional field filters and operators).
+     * @return A {@link SearchTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/search-item/#tablepress-47">Spotify: Search Query Options</a>
+     */
     public Builder q(final String q) {
       assert (q != null);
       assert (!q.equals(""));
       return setQueryParameter("q", q);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. If a country code is given, only artists,
+     *               albums, and tracks with content playable in that market will be returned. (Playlist
+     *               results are not affected by the market parameter.)
+     * @return A {@link SearchTracksRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of results to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link SearchTracksRequest.Builder}.
+     */
     public Builder limit(final Integer limit) {
       assert (limit != null);
       assert (1 <= limit && limit <= 50);
       return setQueryParameter("limit", limit);
     }
 
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first result to return. Default: 0 (i.e., the first result). Maximum
+     *               offset: 100.000. Use with {@link #limit(Integer)} to get the next page of search results.
+     * @return A {@link SearchTracksRequest.Builder}.
+     */
     public Builder offset(final Integer offset) {
       assert (offset != null);
       assert (0 <= offset && offset <= 100000);
       return setQueryParameter("offset", offset);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A {@link SearchTracksRequest.Builder}.
+     */
     @Override
     public SearchTracksRequest build() {
       setPath("/v1/search");

--- a/src/main/java/com/wrapper/spotify/requests/data/tracks/GetAudioAnalysisForTrackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/tracks/GetAudioAnalysisForTrackRequest.java
@@ -6,12 +6,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get a detailed audio analysis for a single track identified by its unique Spotify ID.
+ */
 public class GetAudioAnalysisForTrackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetAudioAnalysisForTrackRequest} constructor.
+   *
+   * @param builder A {@link GetAudioAnalysisForTrackRequest.Builder}.
+   */
   private GetAudioAnalysisForTrackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get an audio analyis for a track.
+   *
+   * @return An {@link AudioAnalysis}.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public AudioAnalysis execute() throws
           IOException,
@@ -19,18 +34,38 @@ public class GetAudioAnalysisForTrackRequest extends AbstractDataRequest {
     return new AudioAnalysis.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetAudioAnalysisForTrackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetAudioAnalysisForTrackRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The track ID setter.
+     *
+     * @param id Required. The Spotify ID for the track.
+     * @return A {@link GetAudioAnalysisForTrackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder id(final String id) {
       assert (id != null);
       assert (!id.equals(""));
       return setPathParameter("id", id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetAudioAnalysisForTrackRequest}.
+     */
     @Override
     public GetAudioAnalysisForTrackRequest build() {
       setPath("/v1/audio-analysis/{id}");

--- a/src/main/java/com/wrapper/spotify/requests/data/tracks/GetAudioFeaturesForSeveralTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/tracks/GetAudioFeaturesForSeveralTracksRequest.java
@@ -6,30 +6,65 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get audio features for multiple tracks based on their Spotify IDs.
+ */
 public class GetAudioFeaturesForSeveralTracksRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetAudioFeaturesForSeveralTracksRequest} constructor.
+   *
+   * @param builder A {@link GetAudioFeaturesForSeveralTracksRequest.Builder}.
+   */
   private GetAudioFeaturesForSeveralTracksRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get audio features for several tracks.
+   *
+   * @return Multiple {@link AudioFeatures} objects.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   public AudioFeatures[] execute() throws
           IOException,
           SpotifyWebApiException {
     return new AudioFeatures.JsonUtil().createModelObjectArray(getJson(), "audio_features");
   }
 
+  /**
+   * Builder class for building a {@link GetAudioFeaturesForSeveralTracksRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetAudioFeaturesForSeveralTracksRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The track IDs setter.
+     *
+     * @param ids Required. A comma-separated list of the Spotify IDs for the tracks. Maximum: 100 IDs.
+     * @return A {@link GetAudioFeaturesForSeveralTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder ids(final String ids) {
       assert (ids != null);
       assert (ids.split(",").length <= 100);
       return setQueryParameter("ids", ids);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetAudioFeaturesForSeveralTracksRequest}.
+     */
     @Override
     public GetAudioFeaturesForSeveralTracksRequest build() {
       setPath("/v1/audio-features");

--- a/src/main/java/com/wrapper/spotify/requests/data/tracks/GetAudioFeaturesForTrackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/tracks/GetAudioFeaturesForTrackRequest.java
@@ -6,12 +6,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get audio feature information for a single track identified by its unique Spotify ID.
+ */
 public class GetAudioFeaturesForTrackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetAudioFeaturesForTrackRequest} constructor.
+   *
+   * @param builder A {@link GetAudioFeaturesForTrackRequest.Builder}.
+   */
   private GetAudioFeaturesForTrackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get audio features for a track.
+   *
+   * @return An {@link AudioFeatures} object.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public AudioFeatures execute() throws
           IOException,
@@ -19,18 +34,38 @@ public class GetAudioFeaturesForTrackRequest extends AbstractDataRequest {
     return new AudioFeatures.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetAudioFeaturesForTrackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetAudioFeaturesForTrackRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The track ID setter.
+     *
+     * @param id Required. The Spotify ID for the track.
+     * @return A {@link GetAudioFeaturesForTrackRequest.Builder}..
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder id(final String id) {
       assert (id != null);
       assert (!id.equals(""));
       return setPathParameter("id", id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetAudioFeaturesForTrackRequest}.
+     */
     @Override
     public GetAudioFeaturesForTrackRequest build() {
       setPath("/v1/audio-features/{id}");

--- a/src/main/java/com/wrapper/spotify/requests/data/tracks/GetSeveralTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/tracks/GetSeveralTracksRequest.java
@@ -7,35 +7,79 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get Spotify catalog information for multiple tracks based on their Spotify IDs.
+ */
 public class GetSeveralTracksRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetSeveralTracksRequest} constructor.
+   *
+   * @param builder A {@link GetSeveralTracksRequest.Builder}.
+   */
   private GetSeveralTracksRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get several tracks.
+   *
+   * @return Multiple {@link Track} objects.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   public Track[] execute() throws
           IOException,
           SpotifyWebApiException {
     return new Track.JsonUtil().createModelObjectArray(getJson(), "tracks");
   }
 
+  /**
+   * Builder class for building a {@link GetSeveralTracksRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetSeveralTracksRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The track IDs setter.
+     *
+     * @param ids Required. A comma-separated list of the Spotify IDs for the tracks. Maximum: 50 IDs.
+     * @return A {@link GetSeveralTracksRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder ids(final String ids) {
       assert (ids != null);
       assert (ids.split(",").length <= 100);
       return setQueryParameter("ids", ids);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. Provide this
+     *               parameter if you want to apply Track Relinking.
+     * @return A {@link GetSeveralTracksRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     * @see <a href="https://developer.spotify.com/web-api/track-relinking-guide/">Spotify: Track Relinking Guide</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetSeveralTracksRequest}.
+     */
     @Override
     public GetSeveralTracksRequest build() {
       setPath("/v1/tracks");

--- a/src/main/java/com/wrapper/spotify/requests/data/tracks/GetTrackRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/tracks/GetTrackRequest.java
@@ -7,12 +7,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get Spotify catalog information for a single track identified by its unique Spotify ID.
+ */
 public class GetTrackRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetTrackRequest} constructor.
+   *
+   * @param builder A {@link GetTrackRequest.Builder}.
+   */
   private GetTrackRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get a track.
+   *
+   * @return A {@link Track}.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public Track execute() throws
           IOException,
@@ -20,23 +35,52 @@ public class GetTrackRequest extends AbstractDataRequest {
     return new Track.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetTrackRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetTrackRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The track ID setter.
+     *
+     * @param id The Spotify ID for the track.
+     * @return A {@link GetTrackRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder id(final String id) {
       assert (id != null);
       assert (!id.equals(""));
       return setPathParameter("id", id);
     }
 
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. Provide this
+     *               parameter if you want to apply Track Relinking.
+     * @return A {@link GetSeveralTracksRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     * @see <a href="https://developer.spotify.com/web-api/track-relinking-guide/">Spotify: Track Relinking Guide</a>
+     */
     public Builder market(final CountryCode market) {
       assert (market != null);
       return setQueryParameter("market", market);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetTrackRequest}.
+     */
     @Override
     public GetTrackRequest build() {
       setPath("/v1/tracks/{id}");

--- a/src/main/java/com/wrapper/spotify/requests/data/users_profile/GetCurrentUsersProfileRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/users_profile/GetCurrentUsersProfileRequest.java
@@ -6,12 +6,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get detailed profile information about the current user (including the current user’s username).
+ */
 public class GetCurrentUsersProfileRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetCurrentUsersProfileRequest} constructor.
+   *
+   * @param builder A {@link GetCurrentUsersProfileRequest.Builder}.
+   */
   private GetCurrentUsersProfileRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get the profile of the current user.
+   *
+   * @return A {@link User}.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public User execute() throws
           IOException,
@@ -19,12 +34,30 @@ public class GetCurrentUsersProfileRequest extends AbstractDataRequest {
     return new User.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetCurrentUsersProfileRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetCurrentUsersProfileRequest.Builder}.
+     * <p>
+     * Reading the user's email address requires the {@code user-read-email} scope; reading
+     * country and product subscription level requires the {@code user-read-private} scope. Reading
+     * the user's birthdate requires the {@code user-read-birthdate} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetCurrentUsersProfileRequest}.
+     */
     @Override
     public GetCurrentUsersProfileRequest build() {
       setPath("/v1/me");

--- a/src/main/java/com/wrapper/spotify/requests/data/users_profile/GetUsersProfileRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/users_profile/GetUsersProfileRequest.java
@@ -6,12 +6,27 @@ import com.wrapper.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get public profile information about a Spotify user.
+ */
 public class GetUsersProfileRequest extends AbstractDataRequest {
 
+  /**
+   * The private {@link GetUsersProfileRequest} constructor.
+   *
+   * @param builder A {@link GetUsersProfileRequest.Builder}.
+   */
   private GetUsersProfileRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get the profile of a current user.
+   *
+   * @return A {@link User}.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @SuppressWarnings("unchecked")
   public User execute() throws
           IOException,
@@ -19,18 +34,38 @@ public class GetUsersProfileRequest extends AbstractDataRequest {
     return new User.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetUsersProfileRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<Builder> {
 
+    /**
+     * Create a new {@link GetUsersProfileRequest.Builder}.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     */
     public Builder(final String accessToken) {
       super(accessToken);
     }
 
+    /**
+     * The user ID setter.
+     *
+     * @param user_id The user's Spotify user ID.
+     * @return A {@link GetUsersProfileRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
     public Builder user_id(final String user_id) {
       assert (user_id != null);
       assert (!user_id.equals(""));
       return setPathParameter("user_id", user_id);
     }
 
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetUsersProfileRequest}.
+     */
     @Override
     public GetUsersProfileRequest build() {
       setPath("/v1/users/{user_id}");


### PR DESCRIPTION
All requests and model objects which can be used to retrieve and represent data from the Spotify Web API now have Javadoc! 🎉 