### PR TITLE
Fix minor style/reference inconsistencies

### DIFF
--- a/src/main/java/com/wrapper/spotify/requests/data/browse/GetRecommendationsRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/browse/GetRecommendationsRequest.java
@@ -65,7 +65,7 @@ public class GetRecommendationsRequest extends AbstractDataRequest {
      * @return A {@link GetRecommendationsRequest.Builder}.
      */
     public Builder limit(final Integer limit) {
-      assert (limit > 0 && limit <= 100);
+      assert (1 <= limit && limit <= 100);
       return setQueryParameter("limit", limit);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/follow/FollowArtistsOrUsersRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/follow/FollowArtistsOrUsersRequest.java
@@ -90,6 +90,7 @@ public class FollowArtistsOrUsersRequest extends AbstractDataRequest {
     public Builder ids(final JsonArray ids) {
       assert (ids != null);
       assert (!ids.isJsonNull());
+      assert (ids.size() <= 50);
       return setBodyParameter("ids", ids);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/follow/UnfollowArtistsOrUsersRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/follow/UnfollowArtistsOrUsersRequest.java
@@ -90,6 +90,7 @@ public class UnfollowArtistsOrUsersRequest extends AbstractDataRequest {
     public Builder ids(final JsonArray ids) {
       assert (ids != null);
       assert (!ids.isJsonNull());
+      assert (ids.size() <= 50);
       return setBodyParameter("ids", ids);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/library/RemoveAlbumsForCurrentUserRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/library/RemoveAlbumsForCurrentUserRequest.java
@@ -75,6 +75,7 @@ public class RemoveAlbumsForCurrentUserRequest extends AbstractDataRequest {
     public Builder ids(final JsonArray ids) {
       assert (ids != null);
       assert (!ids.isJsonNull());
+      assert (ids.size() <= 50);
       return setBodyParameter("ids", ids);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/library/RemoveUsersSavedTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/library/RemoveUsersSavedTracksRequest.java
@@ -75,6 +75,7 @@ public class RemoveUsersSavedTracksRequest extends AbstractDataRequest {
     public Builder ids(final JsonArray ids) {
       assert (ids != null);
       assert (!ids.isJsonNull());
+      assert (ids.size() <= 50);
       return setBodyParameter("ids", ids);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/library/SaveAlbumsForCurrentUserRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/library/SaveAlbumsForCurrentUserRequest.java
@@ -75,6 +75,7 @@ public class SaveAlbumsForCurrentUserRequest extends AbstractDataRequest {
     public Builder ids(final JsonArray ids) {
       assert (ids != null);
       assert (!ids.isJsonNull());
+      assert (ids.size() <= 50);
       return setBodyParameter("ids", ids);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/library/SaveTracksForUserRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/library/SaveTracksForUserRequest.java
@@ -75,6 +75,7 @@ public class SaveTracksForUserRequest extends AbstractDataRequest {
     public Builder ids(final JsonArray ids) {
       assert (ids != null);
       assert (!ids.isJsonNull());
+      assert (ids.size() <= 50);
       return setBodyParameter("ids", ids);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/AddTracksToPlaylistRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/AddTracksToPlaylistRequest.java
@@ -99,6 +99,7 @@ public class AddTracksToPlaylistRequest extends AbstractDataRequest {
     public Builder uris(final String uris) {
       assert (uris != null);
       assert (!uris.equals(""));
+      assert (uris.split(",").length <= 100);
       return setQueryParameter("uris", uris);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/ReplacePlaylistsTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/ReplacePlaylistsTracksRequest.java
@@ -90,6 +90,7 @@ public class ReplacePlaylistsTracksRequest extends AbstractDataRequest {
     public Builder uris(final String uris) {
       assert (uris != null);
       assert (!uris.equals(""));
+      assert (uris.split(",").length <= 100);
       return setQueryParameter("uris", uris);
     }
 

--- a/src/main/java/com/wrapper/spotify/requests/data/tracks/GetSeveralTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/tracks/GetSeveralTracksRequest.java
@@ -57,7 +57,7 @@ public class GetSeveralTracksRequest extends AbstractDataRequest {
      */
     public Builder ids(final String ids) {
       assert (ids != null);
-      assert (ids.split(",").length <= 100);
+      assert (ids.split(",").length <= 50);
       return setQueryParameter("ids", ids);
     }
 


### PR DESCRIPTION
While looking over the new implementation, I happened to see some minor inconsistencies:

- In one instance, the ordering was flipped for x <= limit && limit <= y, it's also inconsistent with the fact that in all other cases >=  and <= is preferred over > and < (not particularly important)
- In a few instances, there was a limit for the number of ids, tracks, etc but there wasn't an assert in the function checking that that limit was respected
- In one instance the limit described in the Javadoc/Web API reference doesn't match the assert limit in the code