### PR TITLE
Adds Retry-After Variable to TooManyRequestsException

### DIFF
--- a/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
@@ -20,7 +20,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClients;
 import org.apache.http.util.EntityUtils;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -50,48 +49,36 @@ public class SpotifyHttpManager implements IHttpManager {
 
 
     CacheConfig cacheConfig = CacheConfig.custom()
-            .setMaxCacheEntries(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_ENTRIES)
-            .setMaxObjectSize(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_OBJECT_SIZE)
-            .setSharedCache(false)
-            .build();
+        .setMaxCacheEntries(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_ENTRIES)
+        .setMaxObjectSize(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_OBJECT_SIZE)
+        .setSharedCache(false).build();
 
-    ConnectionConfig connectionConfig = ConnectionConfig
-            .custom()
-            .setCharset(Charset.forName("UTF-8"))
-            .build();
+    ConnectionConfig connectionConfig =
+        ConnectionConfig.custom().setCharset(Charset.forName("UTF-8")).build();
 
     new BasicCredentialsProvider();
     CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     if (proxy != null) {
       credentialsProvider.setCredentials(
-              new AuthScope(proxy.getHostName(), proxy.getPort(), null, proxy.getSchemeName()),
-              proxyCredentials
-      );
+          new AuthScope(proxy.getHostName(), proxy.getPort(), null, proxy.getSchemeName()),
+          proxyCredentials);
     }
 
-    RequestConfig requestConfig = RequestConfig
-            .custom()
-            .setCookieSpec(CookieSpecs.DEFAULT)
-            .setProxy(proxy)
-            .build();
+    RequestConfig requestConfig =
+        RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).setProxy(proxy).build();
 
 
-    httpClient = CachingHttpClients
-            .custom()
-            .setCacheConfig(cacheConfig)
-            .setDefaultConnectionConfig(connectionConfig)
-            .setDefaultCredentialsProvider(credentialsProvider)
-            .setDefaultRequestConfig(requestConfig)
-            .build();
+    httpClient = CachingHttpClients.custom().setCacheConfig(cacheConfig)
+        .setDefaultConnectionConfig(connectionConfig)
+        .setDefaultCredentialsProvider(credentialsProvider).setDefaultRequestConfig(requestConfig)
+        .build();
   }
 
   public static URI makeUri(String uriString) {
     try {
       return new URI(uriString);
     } catch (URISyntaxException e) {
-      SpotifyApi.LOGGER.log(
-              Level.SEVERE,
-              "URI Syntax Exception for \"" + uriString + "\"");
+      SpotifyApi.LOGGER.log(Level.SEVERE, "URI Syntax Exception for \"" + uriString + "\"");
       return null;
     }
   }
@@ -113,9 +100,7 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String get(URI uri, Header[] headers) throws
-          IOException,
-          SpotifyWebApiException {
+  public String get(URI uri, Header[] headers) throws IOException, SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
@@ -132,9 +117,8 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String post(URI uri, Header[] headers, HttpEntity body) throws
-          IOException,
-          SpotifyWebApiException {
+  public String post(URI uri, Header[] headers, HttpEntity body)
+      throws IOException, SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
@@ -152,9 +136,8 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String put(URI uri, Header[] headers, HttpEntity body) throws
-          IOException,
-          SpotifyWebApiException {
+  public String put(URI uri, Header[] headers, HttpEntity body)
+      throws IOException, SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
@@ -171,9 +154,7 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String delete(URI uri, Header[] headers) throws
-          IOException,
-          SpotifyWebApiException {
+  public String delete(URI uri, Header[] headers) throws IOException, SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
@@ -189,8 +170,7 @@ public class SpotifyHttpManager implements IHttpManager {
     return responseBody;
   }
 
-  private HttpResponse execute(HttpRequestBase method) throws
-          IOException {
+  private HttpResponse execute(HttpRequestBase method) throws IOException {
     HttpCacheContext context = HttpCacheContext.create();
     HttpResponse response = httpClient.execute(method, context);
 
@@ -198,24 +178,19 @@ public class SpotifyHttpManager implements IHttpManager {
       CacheResponseStatus responseStatus = context.getCacheResponseStatus();
       switch (responseStatus) {
         case CACHE_HIT:
-          SpotifyApi.LOGGER.log(
-                  Level.CONFIG,
-                  "A response was generated from the cache with no requests sent upstream");
+          SpotifyApi.LOGGER.log(Level.CONFIG,
+              "A response was generated from the cache with no requests sent upstream");
           break;
         case CACHE_MODULE_RESPONSE:
-          SpotifyApi.LOGGER.log(
-                  Level.CONFIG,
-                  "The response was generated directly by the caching module");
+          SpotifyApi.LOGGER.log(Level.CONFIG,
+              "The response was generated directly by the caching module");
           break;
         case CACHE_MISS:
-          SpotifyApi.LOGGER.log(
-                  Level.CONFIG,
-                  "The response came from an upstream server");
+          SpotifyApi.LOGGER.log(Level.CONFIG, "The response came from an upstream server");
           break;
         case VALIDATED:
-          SpotifyApi.LOGGER.log(
-                  Level.CONFIG,
-                  "The response was generated from the cache after validating the entry with the origin server");
+          SpotifyApi.LOGGER.log(Level.CONFIG,
+              "The response was generated from the cache after validating the entry with the origin server");
           break;
       }
     } catch (Exception e) {
@@ -225,13 +200,11 @@ public class SpotifyHttpManager implements IHttpManager {
     return response;
   }
 
-  private String getResponseBody(HttpResponse httpResponse) throws
-          IOException,
-          SpotifyWebApiException {
+  private String getResponseBody(HttpResponse httpResponse)
+      throws IOException, SpotifyWebApiException {
     final StatusLine statusLine = httpResponse.getStatusLine();
     final String responseBody = httpResponse.getEntity() != null
-            ? EntityUtils.toString(httpResponse.getEntity(), "UTF-8")
-            : null;
+        ? EntityUtils.toString(httpResponse.getEntity(), "UTF-8") : null;
     String errorMessage = statusLine.getReasonPhrase();
 
     if (responseBody != null) {
@@ -241,7 +214,8 @@ public class SpotifyHttpManager implements IHttpManager {
         if (jsonObject.has("error")) {
           if (jsonObject.has("error_description")) {
             errorMessage = jsonObject.get("error_description").getAsString();
-          } else if (jsonObject.get("error").isJsonObject() && jsonObject.getAsJsonObject("error").has("message")) {
+          } else if (jsonObject.get("error").isJsonObject()
+              && jsonObject.getAsJsonObject("error").has("message")) {
             errorMessage = jsonObject.getAsJsonObject("error").get("message").getAsString();
           }
         }
@@ -270,7 +244,18 @@ public class SpotifyHttpManager implements IHttpManager {
       case HttpStatus.SC_NOT_FOUND:
         throw new NotFoundException(errorMessage);
       case 429: // TOO_MANY_REQUESTS (additional status code, RFC 6585)
-        throw new TooManyRequestsException(errorMessage);
+        Header[] headers = httpResponse.getAllHeaders();
+        int retryAfter = -99;
+        for (Header header : headers) {
+          if (header.getName().equalsIgnoreCase("Retry-After")) {
+            retryAfter = Integer.parseInt(header.getValue());
+          }
+        }
+        TooManyRequestsException tmrEx = new TooManyRequestsException(errorMessage);
+        if (retryAfter != -99) {
+          tmrEx.setRetryAfter(retryAfter);
+        }
+        throw tmrEx;
       case HttpStatus.SC_INTERNAL_SERVER_ERROR:
         throw new InternalServerErrorException(errorMessage);
       case HttpStatus.SC_BAD_GATEWAY:

--- a/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
@@ -270,6 +270,7 @@ public class SpotifyHttpManager implements IHttpManager {
       case HttpStatus.SC_NOT_FOUND:
         throw new NotFoundException(errorMessage);
       case 429: // TOO_MANY_REQUESTS (additional status code, RFC 6585)
+        //sets Retry-After from Header as described at https://beta.developer.spotify.com/documentation/web-api/#rate-limiting
         Header[] headers = httpResponse.getAllHeaders();
         int retryAfter = -99;
         for (Header header : headers) {

--- a/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
@@ -20,6 +20,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClients;
 import org.apache.http.util.EntityUtils;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -49,36 +50,48 @@ public class SpotifyHttpManager implements IHttpManager {
 
 
     CacheConfig cacheConfig = CacheConfig.custom()
-        .setMaxCacheEntries(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_ENTRIES)
-        .setMaxObjectSize(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_OBJECT_SIZE)
-        .setSharedCache(false).build();
+            .setMaxCacheEntries(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_ENTRIES)
+            .setMaxObjectSize(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_OBJECT_SIZE)
+            .setSharedCache(false)
+            .build();
 
-    ConnectionConfig connectionConfig =
-        ConnectionConfig.custom().setCharset(Charset.forName("UTF-8")).build();
+    ConnectionConfig connectionConfig = ConnectionConfig
+            .custom()
+            .setCharset(Charset.forName("UTF-8"))
+            .build();
 
     new BasicCredentialsProvider();
     CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     if (proxy != null) {
       credentialsProvider.setCredentials(
-          new AuthScope(proxy.getHostName(), proxy.getPort(), null, proxy.getSchemeName()),
-          proxyCredentials);
+              new AuthScope(proxy.getHostName(), proxy.getPort(), null, proxy.getSchemeName()),
+              proxyCredentials
+      );
     }
 
-    RequestConfig requestConfig =
-        RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).setProxy(proxy).build();
+    RequestConfig requestConfig = RequestConfig
+            .custom()
+            .setCookieSpec(CookieSpecs.DEFAULT)
+            .setProxy(proxy)
+            .build();
 
 
-    httpClient = CachingHttpClients.custom().setCacheConfig(cacheConfig)
-        .setDefaultConnectionConfig(connectionConfig)
-        .setDefaultCredentialsProvider(credentialsProvider).setDefaultRequestConfig(requestConfig)
-        .build();
+    httpClient = CachingHttpClients
+            .custom()
+            .setCacheConfig(cacheConfig)
+            .setDefaultConnectionConfig(connectionConfig)
+            .setDefaultCredentialsProvider(credentialsProvider)
+            .setDefaultRequestConfig(requestConfig)
+            .build();
   }
 
   public static URI makeUri(String uriString) {
     try {
       return new URI(uriString);
     } catch (URISyntaxException e) {
-      SpotifyApi.LOGGER.log(Level.SEVERE, "URI Syntax Exception for \"" + uriString + "\"");
+      SpotifyApi.LOGGER.log(
+              Level.SEVERE,
+              "URI Syntax Exception for \"" + uriString + "\"");
       return null;
     }
   }
@@ -100,7 +113,9 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String get(URI uri, Header[] headers) throws IOException, SpotifyWebApiException {
+  public String get(URI uri, Header[] headers) throws
+          IOException,
+          SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
@@ -117,8 +132,9 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String post(URI uri, Header[] headers, HttpEntity body)
-      throws IOException, SpotifyWebApiException {
+  public String post(URI uri, Header[] headers, HttpEntity body) throws
+          IOException,
+          SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
@@ -136,8 +152,9 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String put(URI uri, Header[] headers, HttpEntity body)
-      throws IOException, SpotifyWebApiException {
+  public String put(URI uri, Header[] headers, HttpEntity body) throws
+          IOException,
+          SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
@@ -154,7 +171,9 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String delete(URI uri, Header[] headers) throws IOException, SpotifyWebApiException {
+  public String delete(URI uri, Header[] headers) throws
+          IOException,
+          SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
@@ -170,7 +189,8 @@ public class SpotifyHttpManager implements IHttpManager {
     return responseBody;
   }
 
-  private HttpResponse execute(HttpRequestBase method) throws IOException {
+  private HttpResponse execute(HttpRequestBase method) throws
+          IOException {
     HttpCacheContext context = HttpCacheContext.create();
     HttpResponse response = httpClient.execute(method, context);
 
@@ -178,19 +198,24 @@ public class SpotifyHttpManager implements IHttpManager {
       CacheResponseStatus responseStatus = context.getCacheResponseStatus();
       switch (responseStatus) {
         case CACHE_HIT:
-          SpotifyApi.LOGGER.log(Level.CONFIG,
-              "A response was generated from the cache with no requests sent upstream");
+          SpotifyApi.LOGGER.log(
+                  Level.CONFIG,
+                  "A response was generated from the cache with no requests sent upstream");
           break;
         case CACHE_MODULE_RESPONSE:
-          SpotifyApi.LOGGER.log(Level.CONFIG,
-              "The response was generated directly by the caching module");
+          SpotifyApi.LOGGER.log(
+                  Level.CONFIG,
+                  "The response was generated directly by the caching module");
           break;
         case CACHE_MISS:
-          SpotifyApi.LOGGER.log(Level.CONFIG, "The response came from an upstream server");
+          SpotifyApi.LOGGER.log(
+                  Level.CONFIG,
+                  "The response came from an upstream server");
           break;
         case VALIDATED:
-          SpotifyApi.LOGGER.log(Level.CONFIG,
-              "The response was generated from the cache after validating the entry with the origin server");
+          SpotifyApi.LOGGER.log(
+                  Level.CONFIG,
+                  "The response was generated from the cache after validating the entry with the origin server");
           break;
       }
     } catch (Exception e) {
@@ -200,11 +225,13 @@ public class SpotifyHttpManager implements IHttpManager {
     return response;
   }
 
-  private String getResponseBody(HttpResponse httpResponse)
-      throws IOException, SpotifyWebApiException {
+  private String getResponseBody(HttpResponse httpResponse) throws
+          IOException,
+          SpotifyWebApiException {
     final StatusLine statusLine = httpResponse.getStatusLine();
     final String responseBody = httpResponse.getEntity() != null
-        ? EntityUtils.toString(httpResponse.getEntity(), "UTF-8") : null;
+            ? EntityUtils.toString(httpResponse.getEntity(), "UTF-8")
+            : null;
     String errorMessage = statusLine.getReasonPhrase();
 
     if (responseBody != null) {
@@ -214,8 +241,7 @@ public class SpotifyHttpManager implements IHttpManager {
         if (jsonObject.has("error")) {
           if (jsonObject.has("error_description")) {
             errorMessage = jsonObject.get("error_description").getAsString();
-          } else if (jsonObject.get("error").isJsonObject()
-              && jsonObject.getAsJsonObject("error").has("message")) {
+          } else if (jsonObject.get("error").isJsonObject() && jsonObject.getAsJsonObject("error").has("message")) {
             errorMessage = jsonObject.getAsJsonObject("error").get("message").getAsString();
           }
         }

--- a/src/main/java/com/wrapper/spotify/exceptions/detailed/BadRequestException.java
+++ b/src/main/java/com/wrapper/spotify/exceptions/detailed/BadRequestException.java
@@ -1,22 +1,55 @@
 package com.wrapper.spotify.exceptions.detailed;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 
 /**
  * The request could not be understood by the server due to malformed syntax.
+ * 
  */
 public class BadRequestException extends SpotifyWebApiException {
+  private String spotifyMessage;
 
   public BadRequestException() {
     super();
   }
 
+  /**
+   * Tries to extract the detailed Errormessage as described here:
+   * https://beta.developer.spotify.com/documentation/web-api/#regular-error-object
+   */
   public BadRequestException(String message) {
     super(message);
+    try {
+      JsonObject detailedMessage = new JsonParser().parse(message).getAsJsonObject();
+      this.spotifyMessage = detailedMessage.get("message").getAsString();
+    } catch (Exception e) {
+      //
+    }
+
   }
 
+  /**
+   * Tries to extract the detailed Errormessage as described here:
+   * https://beta.developer.spotify.com/documentation/web-api/#regular-error-object
+   */
   public BadRequestException(String message, Throwable cause) {
     super(message, cause);
+    try {
+      JsonObject detailedMessage = new JsonParser().parse(message).getAsJsonObject();
+      this.spotifyMessage = detailedMessage.get("message").getAsString();
+    } catch (Exception e) {
+      //
+    }
+  }
+
+  public String getSpotifyMessage() {
+    return spotifyMessage;
+  }
+
+  public void setSpotifyMessage(String spotifyMessage) {
+    this.spotifyMessage = spotifyMessage;
   }
 
 }

--- a/src/main/java/com/wrapper/spotify/exceptions/detailed/BadRequestException.java
+++ b/src/main/java/com/wrapper/spotify/exceptions/detailed/BadRequestException.java
@@ -1,55 +1,22 @@
 package com.wrapper.spotify.exceptions.detailed;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 
 /**
  * The request could not be understood by the server due to malformed syntax.
- * 
  */
 public class BadRequestException extends SpotifyWebApiException {
-  private String spotifyMessage;
 
   public BadRequestException() {
     super();
   }
 
-  /**
-   * Tries to extract the detailed Errormessage as described here:
-   * https://beta.developer.spotify.com/documentation/web-api/#regular-error-object
-   */
   public BadRequestException(String message) {
     super(message);
-    try {
-      JsonObject detailedMessage = new JsonParser().parse(message).getAsJsonObject();
-      this.spotifyMessage = detailedMessage.get("message").getAsString();
-    } catch (Exception e) {
-      //
-    }
-
   }
 
-  /**
-   * Tries to extract the detailed Errormessage as described here:
-   * https://beta.developer.spotify.com/documentation/web-api/#regular-error-object
-   */
   public BadRequestException(String message, Throwable cause) {
     super(message, cause);
-    try {
-      JsonObject detailedMessage = new JsonParser().parse(message).getAsJsonObject();
-      this.spotifyMessage = detailedMessage.get("message").getAsString();
-    } catch (Exception e) {
-      //
-    }
-  }
-
-  public String getSpotifyMessage() {
-    return spotifyMessage;
-  }
-
-  public void setSpotifyMessage(String spotifyMessage) {
-    this.spotifyMessage = spotifyMessage;
   }
 
 }

--- a/src/main/java/com/wrapper/spotify/exceptions/detailed/TooManyRequestsException.java
+++ b/src/main/java/com/wrapper/spotify/exceptions/detailed/TooManyRequestsException.java
@@ -7,8 +7,15 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
  */
 public class TooManyRequestsException extends SpotifyWebApiException {
 
+  private int retryAfter;
+
   public TooManyRequestsException() {
     super();
+  }
+
+  public TooManyRequestsException(String message, int retryAfter) {
+    super(message);
+    this.setRetryAfter(retryAfter);
   }
 
   public TooManyRequestsException(String message) {
@@ -17,6 +24,14 @@ public class TooManyRequestsException extends SpotifyWebApiException {
 
   public TooManyRequestsException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public int getRetryAfter() {
+    return retryAfter;
+  }
+
+  public void setRetryAfter(int retryAfter) {
+    this.retryAfter = retryAfter;
   }
 
 }


### PR DESCRIPTION
Spotify gives you a Retry-After header when API-Request limit is exceeded.

This header is extracted and set to variable inside TooManyRequestsException.

Documentation: https://beta.developer.spotify.com/documentation/web-api/#rate-limiting