### PR TITLE
fix remove tracks from playlist request 

### DIFF
--- a/examples/data/playlists/RemoveTracksFromPlaylistExample.java
+++ b/examples/data/playlists/RemoveTracksFromPlaylistExample.java
@@ -15,7 +15,8 @@ public class RemoveTracksFromPlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
   private static final String userId = "abbaspotify";
   private static final String playlistId = "3AGOiaoRXMSjswCLtuNqv5";
-  private static final JsonArray tracks = new JsonParser().parse("[\"01iyCAUm8EvOFqVWYJ3dVX\"]").getAsJsonArray();
+  private static final JsonArray tracks = new JsonParser()
+          .parse("[{\"uri\":\"spotify:track:01iyCAUm8EvOFqVWYJ3dVX\"}]").getAsJsonArray();
 
   private static final SpotifyApi spotifyApi = new SpotifyApi.Builder()
           .setAccessToken(accessToken)

--- a/src/main/java/com/wrapper/spotify/HttpDeleteBody.java
+++ b/src/main/java/com/wrapper/spotify/HttpDeleteBody.java
@@ -1,0 +1,25 @@
+package com.wrapper.spotify;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
+
+public class HttpDeleteBody extends HttpEntityEnclosingRequestBase {
+    public static final String METHOD_NAME = "DELETE";
+
+    public HttpDeleteBody() {
+    }
+
+    public HttpDeleteBody(URI uri) {
+        this.setURI(uri);
+    }
+
+    public HttpDeleteBody(String uri) {
+        this.setURI(URI.create(uri));
+    }
+
+    public String getMethod() {
+        return "DELETE";
+    }
+}
+

--- a/src/main/java/com/wrapper/spotify/IHttpManager.java
+++ b/src/main/java/com/wrapper/spotify/IHttpManager.java
@@ -62,7 +62,7 @@ public interface IHttpManager {
    * @throws IOException            In case of networking issues.
    * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
    */
-  String delete(URI uri, Header[] headers) throws
+  String delete(URI uri, Header[] headers, HttpEntity body) throws
           IOException,
           SpotifyWebApiException;
 

--- a/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
@@ -171,16 +171,17 @@ public class SpotifyHttpManager implements IHttpManager {
   }
 
   @Override
-  public String delete(URI uri, Header[] headers) throws
+  public String delete(URI uri, Header[] headers, HttpEntity body) throws
           IOException,
           SpotifyWebApiException {
     assert (uri != null);
     assert (!uri.toString().equals(""));
 
-    final HttpDelete httpDelete = new HttpDelete();
+    final HttpDeleteBody httpDelete = new HttpDeleteBody();
 
     httpDelete.setURI(uri);
     httpDelete.setHeaders(headers);
+    httpDelete.setEntity(body);
 
     String responseBody = getResponseBody(execute(httpDelete));
 

--- a/src/main/java/com/wrapper/spotify/requests/AbstractRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/AbstractRequest.java
@@ -156,7 +156,7 @@ public abstract class AbstractRequest implements IRequest {
           SpotifyWebApiException {
     initializeBody();
 
-    String json = httpManager.delete(uri, headers.toArray(new Header[headers.size()]));
+    String json = httpManager.delete(uri, headers.toArray(new Header[headers.size()]), body);
 
     if (json == null || json.equals("")) {
       return null;

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequest.java
@@ -1,10 +1,13 @@
 package com.wrapper.spotify.requests.data.playlists;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.special.SnapshotResult;
 import com.wrapper.spotify.requests.data.AbstractDataRequest;
 import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicNameValuePair;
 
 import java.io.IOException;
 
@@ -35,7 +38,7 @@ public class RemoveTracksFromPlaylistRequest extends AbstractDataRequest {
   public SnapshotResult execute() throws
           IOException,
           SpotifyWebApiException {
-    return new SnapshotResult.JsonUtil().createModelObject(getJson());
+    return new SnapshotResult.JsonUtil().createModelObject(deleteJson());
   }
 
   /**
@@ -103,7 +106,15 @@ public class RemoveTracksFromPlaylistRequest extends AbstractDataRequest {
       assert (tracks != null);
       assert (!tracks.isJsonNull());
       assert (tracks.size() <= 100);
-      return setBodyParameter("tracks", tracks);
+
+      JsonArray formattedArray = new JsonArray();
+      for (JsonElement element : tracks) {
+        JsonObject object = new JsonObject();
+        object.add("uri", element);
+        formattedArray.add(object);
+      }
+
+      return setBodyParameter("tracks", formattedArray);
     }
 
     /**

--- a/src/main/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequest.java
@@ -1,13 +1,10 @@
 package com.wrapper.spotify.requests.data.playlists;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.special.SnapshotResult;
 import com.wrapper.spotify.requests.data.AbstractDataRequest;
 import org.apache.http.entity.ContentType;
-import org.apache.http.message.BasicNameValuePair;
 
 import java.io.IOException;
 
@@ -91,11 +88,11 @@ public class RemoveTracksFromPlaylistRequest extends AbstractDataRequest {
      * <p>
      * There are several ways to specify which tracks to remove, determined by the request parameters.
      * Removing all occurrences of specific tracks: <br>
-     * {@code { "tracks": [{ "uri": "spotify:track:4iV5W9uYEdYUVa79Axb7Rh" },
-     * {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M" }] }} <br>
+     * {@code [{ "uri": "spotify:track:4iV5W9uYEdYUVa79Axb7Rh" },
+     * {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M" }] } <br>
      * Removing a specific occurrence of a track: <br>
-     * {@code { "tracks": [{ "uri": "spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "positions": [0,3] },
-     * { "uri": "spotify:track:1301WleyT98MSxVHPZCA6M", "positions": [7] }] }}
+     * {@code [{ "uri": "spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "positions": [0,3] },
+     * { "uri": "spotify:track:1301WleyT98MSxVHPZCA6M", "positions": [7] }] }
      *
      * @param tracks Required. An array of objects containing Spotify URIs of the tracks to remove. A maximum of
      *               100 objects can be sent at once
@@ -106,15 +103,7 @@ public class RemoveTracksFromPlaylistRequest extends AbstractDataRequest {
       assert (tracks != null);
       assert (!tracks.isJsonNull());
       assert (tracks.size() <= 100);
-
-      JsonArray formattedArray = new JsonArray();
-      for (JsonElement element : tracks) {
-        JsonObject object = new JsonObject();
-        object.add("uri", element);
-        formattedArray.add(object);
-      }
-
-      return setBodyParameter("tracks", formattedArray);
+      return setBodyParameter("tracks", tracks);
     }
 
     /**

--- a/src/test/java/com/wrapper/spotify/TestUtil.java
+++ b/src/test/java/com/wrapper/spotify/TestUtil.java
@@ -55,7 +55,7 @@ public class TestUtil {
       when(mockedHttpManager.get(any(URI.class), any(Header[].class))).thenReturn(fixture);
       when(mockedHttpManager.post(any(URI.class), any(Header[].class), any(HttpEntity.class))).thenReturn(fixture);
       when(mockedHttpManager.put(any(URI.class), any(Header[].class), any(HttpEntity.class))).thenReturn(fixture);
-      when(mockedHttpManager.delete(any(URI.class), any(Header[].class))).thenReturn(fixture);
+      when(mockedHttpManager.delete(any(URI.class), any(Header[].class), any(HttpEntity.class))).thenReturn(fixture);
 
       return mockedHttpManager;
     }

--- a/src/test/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequestTest.java
+++ b/src/test/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequestTest.java
@@ -35,7 +35,7 @@ public class RemoveTracksFromPlaylistRequestTest extends AbstractDataTest<Snapsh
     assertHasBodyParameter(
             defaultRequest,
             "tracks",
-            "[\"" + ID_TRACK + "\",\"" + ID_TRACK + "\"]");
+            "[{\"uri\":\"" + ID_TRACK + "\"},{\"uri\":\"" + ID_TRACK + "\"}]");
     assertEquals(
             "https://api.spotify.com:443/v1/users/abbaspotify/playlists/3AGOiaoRXMSjswCLtuNqv5/tracks",
             defaultRequest.getUri().toString());

--- a/src/test/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequestTest.java
+++ b/src/test/java/com/wrapper/spotify/requests/data/playlists/RemoveTracksFromPlaylistRequestTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 public class RemoveTracksFromPlaylistRequestTest extends AbstractDataTest<SnapshotResult> {
   private final RemoveTracksFromPlaylistRequest defaultRequest = SPOTIFY_API
           .removeTracksFromPlaylist(ID_USER, ID_PLAYLIST, new JsonParser()
-                  .parse("[\"" + ID_TRACK + "\",\"" + ID_TRACK + "\"]").getAsJsonArray())
+                  .parse("[{\"uri\":\"" + ID_TRACK + "\"},{\"uri\":\"" + ID_TRACK + "\"}]").getAsJsonArray())
           .setHttpManager(
                   TestUtil.MockedHttpManager.returningJson(
                           "requests/data/playlists/RemoveTracksFromPlaylistRequest.json"))


### PR DESCRIPTION
Remove tracks on playlist request (https://developer.spotify.com/web-api/remove-tracks-playlist/) requires that the http delete body contains formatting like
 `{ "tracks": [{ "uri": "spotify:track:4iV5W9uYEdYUVa79Axb7Rh" },{"uri": "spotify:track:1301WleyT98MSxVHPZCA6M" }] }`
This PR adds a method that allows a body in the http delete method as well as updates the formatting of the tracks array so that it matches what spotify expects. 