### PR TITLE
Possible fix for #140

### DIFF
--- a/src/main/java/com/wrapper/spotify/SpotifyApi.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyApi.java
@@ -31,7 +31,9 @@ import com.wrapper.spotify.requests.data.users_profile.GetCurrentUsersProfileReq
 import com.wrapper.spotify.requests.data.users_profile.GetUsersProfileRequest;
 
 import java.net.URI;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.TimeZone;
 import java.util.logging.Logger;
 
@@ -81,8 +83,12 @@ public class SpotifyApi {
    * The date format used by the Spotify Web API. It uses the {@code GMT}  timezone and the following pattern:
    * {@code yyyy-MM-dd'T'HH:mm:ss}
    */
-  public static final SimpleDateFormat SIMPLE_DATE_FORMAT = makeSimpleDateFormat(
-          "yyyy-MM-dd'T'HH:mm:ss", "GMT");
+  private static final ThreadLocal<SimpleDateFormat> SIMPLE_DATE_FORMAT = new ThreadLocal<SimpleDateFormat>()  {
+    @Override
+    protected SimpleDateFormat initialValue() {
+      return makeSimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", "GMT");
+    }
+  };
 
   private final IHttpManager httpManager;
   private final String scheme;
@@ -142,6 +148,27 @@ public class SpotifyApi {
     stringBuilder.deleteCharAt(stringBuilder.length() - 1);
 
     return stringBuilder.toString();
+  }
+
+  /**
+   * Parses a date in the default spotify format.
+   *
+   * @param date the input date to parse
+   * @return the pared {@link Date}
+   * @throws ParseException if the date is not in a valid format
+   */
+  public static Date parseDefaultDate(String date) throws ParseException {
+    return SIMPLE_DATE_FORMAT.get().parse(date);
+  }
+
+  /**
+   * Formats a date, using the default spotify format.
+   *
+   * @param date the date to format
+   * @return the formatted date
+   */
+  public static String formatDefaultDate(Date date) {
+    return SIMPLE_DATE_FORMAT.get().format(date);
   }
 
   public static SimpleDateFormat makeSimpleDateFormat(String pattern, String id) {

--- a/src/main/java/com/wrapper/spotify/model_objects/specification/PlayHistory.java
+++ b/src/main/java/com/wrapper/spotify/model_objects/specification/PlayHistory.java
@@ -122,7 +122,7 @@ public class PlayHistory extends AbstractModelObject {
                                 : null)
                 .setPlayedAt(
                         hasAndNotNull(jsonObject, "played_at")
-                                ? SpotifyApi.SIMPLE_DATE_FORMAT.parse(jsonObject.get("played_at").getAsString())
+                                ? SpotifyApi.parseDefaultDate(jsonObject.get("played_at").getAsString())
                                 : null)
                 .setContext(
                         hasAndNotNull(jsonObject, "context")

--- a/src/main/java/com/wrapper/spotify/model_objects/specification/PlaylistTrack.java
+++ b/src/main/java/com/wrapper/spotify/model_objects/specification/PlaylistTrack.java
@@ -143,7 +143,7 @@ public class PlaylistTrack extends AbstractModelObject {
         return new Builder()
                 .setAddedAt(
                         hasAndNotNull(jsonObject, "added_at")
-                                ? SpotifyApi.SIMPLE_DATE_FORMAT.parse(jsonObject.get("added_at").getAsString())
+                                ? SpotifyApi.parseDefaultDate(jsonObject.get("added_at").getAsString())
                                 : null)
                 .setAddedBy(
                         hasAndNotNull(jsonObject, "added_by")

--- a/src/main/java/com/wrapper/spotify/model_objects/specification/SavedAlbum.java
+++ b/src/main/java/com/wrapper/spotify/model_objects/specification/SavedAlbum.java
@@ -94,7 +94,7 @@ public class SavedAlbum extends AbstractModelObject {
         return new Builder()
                 .setAddedAt(
                         hasAndNotNull(jsonObject, "added_at")
-                                ? SpotifyApi.SIMPLE_DATE_FORMAT.parse(jsonObject.get("added_at").getAsString())
+                                ? SpotifyApi.parseDefaultDate(jsonObject.get("added_at").getAsString())
                                 : null)
                 .setAlbum(
                         hasAndNotNull(jsonObject, "album")

--- a/src/main/java/com/wrapper/spotify/model_objects/specification/SavedTrack.java
+++ b/src/main/java/com/wrapper/spotify/model_objects/specification/SavedTrack.java
@@ -94,7 +94,7 @@ public class SavedTrack extends AbstractModelObject {
         return new Builder()
                 .setAddedAt(
                         hasAndNotNull(jsonObject, "added_at")
-                                ? SpotifyApi.SIMPLE_DATE_FORMAT.parse(jsonObject.get("added_at").getAsString())
+                                ? SpotifyApi.parseDefaultDate(jsonObject.get("added_at").getAsString())
                                 : null)
                 .setTrack(
                         hasAndNotNull(jsonObject, "track")

--- a/src/main/java/com/wrapper/spotify/requests/data/browse/GetListOfFeaturedPlaylistsRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/browse/GetListOfFeaturedPlaylistsRequest.java
@@ -102,7 +102,7 @@ public class GetListOfFeaturedPlaylistsRequest extends AbstractDataRequest {
      */
     public Builder timestamp(final Date timestamp) {
       assert (timestamp != null);
-      return setQueryParameter("timestamp", SpotifyApi.SIMPLE_DATE_FORMAT.format(timestamp));
+      return setQueryParameter("timestamp", SpotifyApi.formatDefaultDate(timestamp));
     }
 
     /**

--- a/src/main/java/com/wrapper/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequest.java
@@ -87,7 +87,7 @@ public class GetCurrentUsersRecentlyPlayedTracksRequest extends AbstractDataRequ
      */
     public Builder after(final Date after) {
       assert (after != null);
-      return setQueryParameter("after", SpotifyApi.SIMPLE_DATE_FORMAT.format(after));
+      return setQueryParameter("after", SpotifyApi.formatDefaultDate(after));
     }
 
     /**
@@ -99,7 +99,7 @@ public class GetCurrentUsersRecentlyPlayedTracksRequest extends AbstractDataRequ
      */
     public Builder before(final Date before) {
       assert (before != null);
-      return setQueryParameter("before", SpotifyApi.SIMPLE_DATE_FORMAT.format(before));
+      return setQueryParameter("before", SpotifyApi.formatDefaultDate(before));
     }
 
     /**


### PR DESCRIPTION
## General description
This commit introduces a ThreadLocal cache for the SimpleDateFormat in question (`SpotifyApi.SIMPLE_DATE_FORMAT`). This ensures that the format is never shared between threads, which could otherwise lead to problems as it is not thread safe by itself.

The public field was replaced with a private one and two methods, for parsing and formatting.
All changes to classes unrelated to `SpotifyApi` are just minor adjustments to make them use the new methods instead.

All existing tests passed and this is not really a major change, but some more testing is probably still a good idea.

## Problems
* No unit test(s). Suggestions on how to test that behaviour are welcome
* I am not quite sure where the comment describing the format belongs now
* Not quite sure whether it matches the styleguide, but I did also not find an official one. That might be on me though.
