### PR TITLE
Fix issue where measure was not being parsed correctly in segment and section

### DIFF
--- a/src/main/java/com/wrapper/spotify/model_objects/miscellaneous/AudioAnalysisSection.java
+++ b/src/main/java/com/wrapper/spotify/model_objects/miscellaneous/AudioAnalysisSection.java
@@ -290,11 +290,7 @@ public class AudioAnalysisSection extends AbstractModelObject {
                               ? jsonObject.get("loudness").getAsFloat()
                               : null)
               .setMeasure(
-                      (hasAndNotNull(jsonObject, "start")
-                              && hasAndNotNull(jsonObject, "duration")
-                              && hasAndNotNull(jsonObject, "confidence"))
-                              ? new AudioAnalysisMeasure.JsonUtil().createModelObject(jsonObject)
-                              : null)
+                      new AudioAnalysisMeasure.JsonUtil().createModelObject(jsonObject))
               .setMode(
                       hasAndNotNull(jsonObject, "type")
                               ? Modality.keyOf(

--- a/src/main/java/com/wrapper/spotify/model_objects/miscellaneous/AudioAnalysisSection.java
+++ b/src/main/java/com/wrapper/spotify/model_objects/miscellaneous/AudioAnalysisSection.java
@@ -290,9 +290,10 @@ public class AudioAnalysisSection extends AbstractModelObject {
                               ? jsonObject.get("loudness").getAsFloat()
                               : null)
               .setMeasure(
-                      hasAndNotNull(jsonObject, "measure")
-                              ? new AudioAnalysisMeasure.JsonUtil().createModelObject(
-                              jsonObject.getAsJsonObject("measure"))
+                      (hasAndNotNull(jsonObject, "start")
+                              && hasAndNotNull(jsonObject, "duration")
+                              && hasAndNotNull(jsonObject, "confidence"))
+                              ? new AudioAnalysisMeasure.JsonUtil().createModelObject(jsonObject)
                               : null)
               .setMode(
                       hasAndNotNull(jsonObject, "type")

--- a/src/main/java/com/wrapper/spotify/model_objects/miscellaneous/AudioAnalysisSegment.java
+++ b/src/main/java/com/wrapper/spotify/model_objects/miscellaneous/AudioAnalysisSegment.java
@@ -231,11 +231,7 @@ public class AudioAnalysisSegment extends AbstractModelObject {
                               ? jsonObject.get("loudness_start").getAsFloat()
                               : null)
               .setMeasure(
-                      (hasAndNotNull(jsonObject, "start")
-                              && hasAndNotNull(jsonObject, "duration")
-                              && hasAndNotNull(jsonObject, "confidence"))
-                              ? new AudioAnalysisMeasure.JsonUtil().createModelObject(jsonObject)
-                              : null)
+                      new AudioAnalysisMeasure.JsonUtil().createModelObject(jsonObject))
               .setPitches(
                       hasAndNotNull(jsonObject, "pitches")
                               ? new Gson().fromJson(jsonObject.getAsJsonArray("pitches"), float[].class)

--- a/src/main/java/com/wrapper/spotify/model_objects/miscellaneous/AudioAnalysisSegment.java
+++ b/src/main/java/com/wrapper/spotify/model_objects/miscellaneous/AudioAnalysisSegment.java
@@ -231,9 +231,10 @@ public class AudioAnalysisSegment extends AbstractModelObject {
                               ? jsonObject.get("loudness_start").getAsFloat()
                               : null)
               .setMeasure(
-                      hasAndNotNull(jsonObject, "measure")
-                              ? new AudioAnalysisMeasure.JsonUtil().createModelObject(
-                              jsonObject.getAsJsonObject("measure"))
+                      (hasAndNotNull(jsonObject, "start")
+                              && hasAndNotNull(jsonObject, "duration")
+                              && hasAndNotNull(jsonObject, "confidence"))
+                              ? new AudioAnalysisMeasure.JsonUtil().createModelObject(jsonObject)
                               : null)
               .setPitches(
                       hasAndNotNull(jsonObject, "pitches")


### PR DESCRIPTION
sections and segments do not contain a "measure" object in json, they contain the 3 elements (start, duration, confidence) as top-level objects. This means that the code does not return a measure object because it cannot find a measure object in the json, so it skips parsing that section.

Implemented change means that the code no longer attempts to pull a measure object out of the segment/section json, and instead passes the entire segment/section json object to the AudioAnalysisMeasure parser.