### PR TITLE
Add ability to set http request timeouts in HttpManager

### DIFF
--- a/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
@@ -36,6 +36,9 @@ public class SpotifyHttpManager implements IHttpManager {
   private final UsernamePasswordCredentials proxyCredentials;
   private final Integer cacheMaxEntries;
   private final Integer cacheMaxObjectSize;
+  private final Integer connectionRequestTimeout;
+  private final Integer connectTimeout;
+  private final Integer socketTimeout;
 
   /**
    * Construct a new SpotifyHttpManager instance.
@@ -47,6 +50,9 @@ public class SpotifyHttpManager implements IHttpManager {
     this.proxyCredentials = builder.proxyCredentials;
     this.cacheMaxEntries = builder.cacheMaxEntries;
     this.cacheMaxObjectSize = builder.cacheMaxObjectSize;
+    this.connectionRequestTimeout = builder.connectionRequestTimeout;
+    this.connectTimeout = builder.connectTimeout;
+    this.socketTimeout = builder.socketTimeout;
 
 
     CacheConfig cacheConfig = CacheConfig.custom()
@@ -73,6 +79,15 @@ public class SpotifyHttpManager implements IHttpManager {
             .custom()
             .setCookieSpec(CookieSpecs.DEFAULT)
             .setProxy(proxy)
+            .setConnectionRequestTimeout(builder.connectionRequestTimeout != null
+                    ? builder.connectionRequestTimeout
+                    : RequestConfig.DEFAULT.getConnectionRequestTimeout())
+            .setConnectTimeout(builder.connectTimeout != null
+                    ? builder.connectTimeout
+                    : RequestConfig.DEFAULT.getConnectTimeout())
+            .setSocketTimeout(builder.socketTimeout != null
+                    ? builder.socketTimeout
+                    : RequestConfig.DEFAULT.getSocketTimeout())
             .build();
 
 
@@ -110,6 +125,18 @@ public class SpotifyHttpManager implements IHttpManager {
 
   public Integer getCacheMaxObjectSize() {
     return cacheMaxObjectSize;
+  }
+
+  public Integer getConnectionRequestTimeout() {
+    return connectionRequestTimeout;
+  }
+
+  public Integer getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  public Integer getSocketTimeout() {
+    return socketTimeout;
   }
 
   @Override
@@ -296,6 +323,9 @@ public class SpotifyHttpManager implements IHttpManager {
     private UsernamePasswordCredentials proxyCredentials;
     private Integer cacheMaxEntries;
     private Integer cacheMaxObjectSize;
+    private Integer connectionRequestTimeout;
+    private Integer connectTimeout;
+    private Integer socketTimeout;
 
     public Builder setProxy(HttpHost proxy) {
       this.proxy = proxy;
@@ -314,6 +344,21 @@ public class SpotifyHttpManager implements IHttpManager {
 
     public Builder setCacheMaxObjectSize(Integer cacheMaxObjectSize) {
       this.cacheMaxObjectSize = cacheMaxObjectSize;
+      return this;
+    }
+
+    public Builder setConnectionRequestTimeout(Integer connectionRequestTimeout) {
+      this.connectionRequestTimeout = connectionRequestTimeout;
+      return this;
+    }
+
+    public Builder setConnectTimeout(Integer connectTimeout) {
+      this.connectTimeout = connectTimeout;
+      return this;
+    }
+
+    public Builder setSocketTimeout(Integer socketTimeout) {
+      this.socketTimeout = socketTimeout;
       return this;
     }
 

--- a/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
@@ -57,7 +57,7 @@ public class SpotifyHttpManager implements IHttpManager {
 
     CacheConfig cacheConfig = CacheConfig.custom()
             .setMaxCacheEntries(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_ENTRIES)
-            .setMaxObjectSize(cacheMaxEntries != null ? cacheMaxEntries : DEFAULT_CACHE_MAX_OBJECT_SIZE)
+            .setMaxObjectSize(cacheMaxObjectSize != null ? cacheMaxObjectSize : DEFAULT_CACHE_MAX_OBJECT_SIZE)
             .setSharedCache(false)
             .build();
 


### PR DESCRIPTION
I created PR in case anyone needs to set custom timeout for http client that can prevent potential issues with 'infinite http requests' (that I have observed).

Also I noticed one potential problem with SpotifyHttpManager but decided not to change code because I am not aware of intentions why 'CloseableHttpClient httpClient' is a static field. At least for me it caused troubles when order of initialization was different for 'custom http client' and 'default http client'.
In other words this looks like a side side effect that can take place when 'custom httpClient' is initialized first, then it can be overridden by other instances of SpotifyHttpManager class e.g. created by 'new SpotifyApi.Builder()'. 