### PR TITLE
Async improvements - CompletableFuture 

### DIFF
--- a/examples/authorization/authorization_code/AuthorizationCodeExample.java
+++ b/examples/authorization/authorization_code/AuthorizationCodeExample.java
@@ -8,8 +8,9 @@ import com.wrapper.spotify.requests.authorization.authorization_code.Authorizati
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class AuthorizationCodeExample {
   private static final String clientId = "zyuxhfo1c51b5hxjk09x2uhv5n0svgd6g";
@@ -41,19 +42,22 @@ public class AuthorizationCodeExample {
 
   public static void authorizationCode_Async() {
     try {
-      final Future<AuthorizationCodeCredentials> authorizationCodeCredentialsFuture = authorizationCodeRequest.executeAsync();
+      final CompletableFuture<AuthorizationCodeCredentials> authorizationCodeCredentialsFuture = authorizationCodeRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final AuthorizationCodeCredentials authorizationCodeCredentials = authorizationCodeCredentialsFuture.get();
+      // Example Only. Never block in production code.
+      final AuthorizationCodeCredentials authorizationCodeCredentials = authorizationCodeCredentialsFuture.join();
 
       // Set access and refresh token for further "spotifyApi" object usage
       spotifyApi.setAccessToken(authorizationCodeCredentials.getAccessToken());
       spotifyApi.setRefreshToken(authorizationCodeCredentials.getRefreshToken());
 
       System.out.println("Expires in: " + authorizationCodeCredentials.getExpiresIn());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/authorization/authorization_code/AuthorizationCodeRefreshExample.java
+++ b/examples/authorization/authorization_code/AuthorizationCodeRefreshExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.credentials.AuthorizationCodeCredential
 import com.wrapper.spotify.requests.authorization.authorization_code.AuthorizationCodeRefreshRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class AuthorizationCodeRefreshExample {
   private static final String clientId = "zyuxhfo1c51b5hxjk09x2uhv5n0svgd6g";
@@ -38,18 +39,21 @@ public class AuthorizationCodeRefreshExample {
 
   public static void authorizationCodeRefresh_Async() {
     try {
-      final Future<AuthorizationCodeCredentials> authorizationCodeCredentialsFuture = authorizationCodeRefreshRequest.executeAsync();
+      final CompletableFuture<AuthorizationCodeCredentials> authorizationCodeCredentialsFuture = authorizationCodeRefreshRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final AuthorizationCodeCredentials authorizationCodeCredentials = authorizationCodeCredentialsFuture.get();
+      // Example Only. Never block in production code.
+      final AuthorizationCodeCredentials authorizationCodeCredentials = authorizationCodeCredentialsFuture.join();
 
       // Set access token for further "spotifyApi" object usage
       spotifyApi.setAccessToken(authorizationCodeCredentials.getAccessToken());
 
       System.out.println("Expires in: " + authorizationCodeCredentials.getExpiresIn());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/authorization/authorization_code/AuthorizationCodeUriExample.java
+++ b/examples/authorization/authorization_code/AuthorizationCodeUriExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.SpotifyHttpManager;
 import com.wrapper.spotify.requests.authorization.authorization_code.AuthorizationCodeUriRequest;
 
 import java.net.URI;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class AuthorizationCodeUriExample {
   private static final String clientId = "zyuxhfo1c51b5hxjk09x2uhv5n0svgd6g";
@@ -32,15 +33,18 @@ public class AuthorizationCodeUriExample {
 
   public static void authorizationCodeUri_Async() {
     try {
-      final Future<URI> uriFuture = authorizationCodeUriRequest.executeAsync();
+      final CompletableFuture<URI> uriFuture = authorizationCodeUriRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final URI uri = uriFuture.get();
+      // Example Only. Never block in production code.
+      final URI uri = uriFuture.join();
 
       System.out.println("URI: " + uri.toString());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/authorization/client_credentials/ClientCredentialsExample.java
+++ b/examples/authorization/client_credentials/ClientCredentialsExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.credentials.ClientCredentials;
 import com.wrapper.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class ClientCredentialsExample {
   private static final String clientId = "zyuxhfo1c51b5hxjk09x2uhv5n0svgd6g";
@@ -35,18 +36,21 @@ public class ClientCredentialsExample {
 
   public static void clientCredentials_Async() {
     try {
-      final Future<ClientCredentials> clientCredentialsFuture = clientCredentialsRequest.executeAsync();
+      final CompletableFuture<ClientCredentials> clientCredentialsFuture = clientCredentialsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final ClientCredentials clientCredentials = clientCredentialsFuture.get();
+      // Example Only. Never block in production code.
+      final ClientCredentials clientCredentials = clientCredentialsFuture.join();
 
       // Set access token for further "spotifyApi" object usage
       spotifyApi.setAccessToken(clientCredentials.getAccessToken());
 
       System.out.println("Expires in: " + clientCredentials.getExpiresIn());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/albums/GetAlbumExample.java
+++ b/examples/data/albums/GetAlbumExample.java
@@ -1,14 +1,14 @@
 package data.albums;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Album;
 import com.wrapper.spotify.requests.data.albums.GetAlbumRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetAlbumExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +33,18 @@ public class GetAlbumExample {
 
   public static void getAlbum_Async() {
     try {
-      final Future<Album> albumFuture = getAlbumRequest.executeAsync();
+      final CompletableFuture<Album> albumFuture = getAlbumRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Album album = albumFuture.get();
+      // Example Only. Never block in production code.
+      final Album album = albumFuture.join();
 
       System.out.println("Name: " + album.getName());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/albums/GetAlbumsTracksExample.java
+++ b/examples/data/albums/GetAlbumsTracksExample.java
@@ -1,6 +1,5 @@
 package data.albums;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Paging;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.TrackSimplified;
 import com.wrapper.spotify.requests.data.albums.GetAlbumsTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetAlbumsTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +36,18 @@ public class GetAlbumsTracksExample {
 
   public static void getAlbumsTracks_Async() {
     try {
-      final Future<Paging<TrackSimplified>> pagingFuture = getAlbumsTracksRequest.executeAsync();
+      final CompletableFuture<Paging<TrackSimplified>> pagingFuture = getAlbumsTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<TrackSimplified> trackSimplifiedPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<TrackSimplified> trackSimplifiedPaging = pagingFuture.join();
 
       System.out.println("Total: " + trackSimplifiedPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/albums/GetSeveralAlbumsExample.java
+++ b/examples/data/albums/GetSeveralAlbumsExample.java
@@ -1,14 +1,14 @@
 package data.albums;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Album;
 import com.wrapper.spotify.requests.data.albums.GetSeveralAlbumsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetSeveralAlbumsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +33,18 @@ public class GetSeveralAlbumsExample {
 
   public static void getSeveralAlbums_Async() {
     try {
-      final Future<Album[]> albumsFuture = getSeveralAlbumsRequest.executeAsync();
+      final CompletableFuture<Album[]> albumsFuture = getSeveralAlbumsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Album[] albums = albumsFuture.get();
+      // Example Only. Never block in production code.
+      final Album[] albums = albumsFuture.join();
 
       System.out.println("Length: " + albums.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/artists/GetArtistExample.java
+++ b/examples/data/artists/GetArtistExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.Artist;
 import com.wrapper.spotify.requests.data.artists.GetArtistRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetArtistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +32,18 @@ public class GetArtistExample {
 
   public static void getArtist_Async() {
     try {
-      final Future<Artist> albumFuture = getArtistRequest.executeAsync();
+      final CompletableFuture<Artist> albumFuture = getArtistRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Artist artist = albumFuture.get();
+      // Example Only. Never block in production code.
+      final Artist artist = albumFuture.join();
 
       System.out.println("Name: " + artist.getName());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/artists/GetArtistsAlbumsExample.java
+++ b/examples/data/artists/GetArtistsAlbumsExample.java
@@ -1,6 +1,5 @@
 package data.artists;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.AlbumSimplified;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.Paging;
 import com.wrapper.spotify.requests.data.artists.GetArtistsAlbumsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetArtistsAlbumsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -37,15 +37,18 @@ public class GetArtistsAlbumsExample {
 
   public static void getArtistsAlbums_Async() {
     try {
-      final Future<Paging<AlbumSimplified>> pagingFuture = getArtistsAlbumsRequest.executeAsync();
+      final CompletableFuture<Paging<AlbumSimplified>> pagingFuture = getArtistsAlbumsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<AlbumSimplified> albumSimplifiedPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<AlbumSimplified> albumSimplifiedPaging = pagingFuture.join();
 
       System.out.println("Total: " + albumSimplifiedPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/artists/GetArtistsRelatedArtistsExample.java
+++ b/examples/data/artists/GetArtistsRelatedArtistsExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.Artist;
 import com.wrapper.spotify.requests.data.artists.GetArtistsRelatedArtistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetArtistsRelatedArtistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +33,18 @@ public class GetArtistsRelatedArtistsExample {
 
   public static void getArtistsRelatedArtists_Async() {
     try {
-      final Future<Artist[]> artistsFuture = getArtistsRelatedArtistsRequest.executeAsync();
+      final CompletableFuture<Artist[]> artistsFuture = getArtistsRelatedArtistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Artist[] artists = artistsFuture.get();
+      // Example Only. Never block in production code.
+      final Artist[] artists = artistsFuture.join();
 
       System.out.println("Length: " + artists.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/artists/GetArtistsTopTracksExample.java
+++ b/examples/data/artists/GetArtistsTopTracksExample.java
@@ -7,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.Track;
 import com.wrapper.spotify.requests.data.artists.GetArtistsTopTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetArtistsTopTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -34,15 +35,18 @@ public class GetArtistsTopTracksExample {
 
   public static void getArtistsTopTracks_Async() {
     try {
-      final Future<Track[]> artistsFuture = getArtistsTopTracksRequest.executeAsync();
+      final CompletableFuture<Track[]> artistsFuture = getArtistsTopTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Track[] tracks = artistsFuture.get();
+      // Example Only. Never block in production code.
+      final Track[] tracks = artistsFuture.join();
 
       System.out.println("Length: " + tracks.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/artists/GetSeveralArtistsExample.java
+++ b/examples/data/artists/GetSeveralArtistsExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.Artist;
 import com.wrapper.spotify.requests.data.artists.GetSeveralArtistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetSeveralArtistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +32,18 @@ public class GetSeveralArtistsExample {
 
   public static void getSeveralArtists_Async() {
     try {
-      final Future<Artist[]> artistFuture = getSeveralArtistsRequest.executeAsync();
+      final CompletableFuture<Artist[]> artistFuture = getSeveralArtistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Artist[] artists = artistFuture.get();
+      // Example Only. Never block in production code.
+      final Artist[] artists = artistFuture.join();
 
       System.out.println("Length: " + artists.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/browse/GetCategoryExample.java
+++ b/examples/data/browse/GetCategoryExample.java
@@ -7,8 +7,7 @@ import com.wrapper.spotify.model_objects.specification.Category;
 import com.wrapper.spotify.requests.data.browse.GetCategoryRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class GetCategoryExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -34,15 +33,18 @@ public class GetCategoryExample {
 
   public static void getCategory_Async() {
     try {
-      final Future<Category> categoryFuture = getCategoryRequest.executeAsync();
+      final CompletableFuture<Category> categoryFuture = getCategoryRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Category category = categoryFuture.get();
+      // Example Only. Never block in production code.
+      final Category category = categoryFuture.join();
 
       System.out.println("Name: " + category.getName());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/browse/GetCategorysPlaylistsExample.java
+++ b/examples/data/browse/GetCategorysPlaylistsExample.java
@@ -1,6 +1,5 @@
 package data.browse;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Paging;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.PlaylistSimplified;
 import com.wrapper.spotify.requests.data.browse.GetCategorysPlaylistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetCategorysPlaylistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +36,18 @@ public class GetCategorysPlaylistsExample {
 
   public static void getCategorysPlaylists_Async() {
     try {
-      final Future<Paging<PlaylistSimplified>> pagingFuture = getCategoryRequest.executeAsync();
+      final CompletableFuture<Paging<PlaylistSimplified>> pagingFuture = getCategoryRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<PlaylistSimplified> playlistSimplifiedPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<PlaylistSimplified> playlistSimplifiedPaging = pagingFuture.join();
 
       System.out.println("Total: " + playlistSimplifiedPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/browse/GetListOfCategoriesExample.java
+++ b/examples/data/browse/GetListOfCategoriesExample.java
@@ -1,6 +1,5 @@
 package data.browse;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Category;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.Paging;
 import com.wrapper.spotify.requests.data.browse.GetListOfCategoriesRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetListOfCategoriesExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +36,18 @@ public class GetListOfCategoriesExample {
 
   public static void getListOfCategories_Async() {
     try {
-      final Future<Paging<Category>> pagingFuture = getListOfCategoriesRequest.executeAsync();
+      final CompletableFuture<Paging<Category>> pagingFuture = getListOfCategoriesRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<Category> categoryPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<Category> categoryPaging = pagingFuture.join();
 
       System.out.println("Total: " + categoryPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/browse/GetListOfFeaturedPlaylistsExample.java
+++ b/examples/data/browse/GetListOfFeaturedPlaylistsExample.java
@@ -1,15 +1,14 @@
 package data.browse;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.special.FeaturedPlaylists;
 import com.wrapper.spotify.requests.data.browse.GetListOfFeaturedPlaylistsRequest;
 
 import java.io.IOException;
-import java.util.Date;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetListOfFeaturedPlaylistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -37,15 +36,18 @@ public class GetListOfFeaturedPlaylistsExample {
 
   public static void getListOfFeaturedPlaylists_Async() {
     try {
-      final Future<FeaturedPlaylists> featuredPlaylistsFuture = getListOfFeaturedPlaylistsRequest.executeAsync();
+      final CompletableFuture<FeaturedPlaylists> featuredPlaylistsFuture = getListOfFeaturedPlaylistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final FeaturedPlaylists featuredPlaylists = featuredPlaylistsFuture.get();
+      // Example Only. Never block in production code.
+      final FeaturedPlaylists featuredPlaylists = featuredPlaylistsFuture.join();
 
       System.out.println("Message: " + featuredPlaylists.getMessage());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/browse/GetListOfNewReleasesExample.java
+++ b/examples/data/browse/GetListOfNewReleasesExample.java
@@ -1,6 +1,5 @@
 package data.browse;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.AlbumSimplified;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.Paging;
 import com.wrapper.spotify.requests.data.browse.GetListOfNewReleasesRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetListOfNewReleasesExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -35,15 +35,18 @@ public class GetListOfNewReleasesExample {
 
   public static void getListOfNewReleases_Async() {
     try {
-      final Future<Paging<AlbumSimplified>> pagingFuture = getListOfNewReleasesRequest.executeAsync();
+      final CompletableFuture<Paging<AlbumSimplified>> pagingFuture = getListOfNewReleasesRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<AlbumSimplified> albumSimplifiedPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<AlbumSimplified> albumSimplifiedPaging = pagingFuture.join();
 
       System.out.println("Total: " + albumSimplifiedPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/browse/GetRecommendationsExample.java
+++ b/examples/data/browse/GetRecommendationsExample.java
@@ -1,14 +1,14 @@
 package data.browse;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Recommendations;
 import com.wrapper.spotify.requests.data.browse.GetRecommendationsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetRecommendationsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -39,15 +39,18 @@ public class GetRecommendationsExample {
 
   public static void getRecommendations_Async() {
     try {
-      final Future<Recommendations> recommendationsFuture = getRecommendationsRequest.executeAsync();
+      final CompletableFuture<Recommendations> recommendationsFuture = getRecommendationsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Recommendations recommendations = recommendationsFuture.get();
+      // Example Only. Never block in production code.
+      final Recommendations recommendations = recommendationsFuture.join();
 
       System.out.println("Length: " + recommendations.getTracks().length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/browse/miscellaneous/GetAvailableGenreSeedsExample.java
+++ b/examples/data/browse/miscellaneous/GetAvailableGenreSeedsExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.browse.miscellaneous.GetAvailableGenreSeedsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetAvailableGenreSeedsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -29,15 +30,18 @@ public class GetAvailableGenreSeedsExample {
 
   public static void getAvailableGenreSeeds_Async() {
     try {
-      final Future<String[]> stringsFuture = getAvailableGenreSeedsRequest.executeAsync();
+      final CompletableFuture<String[]> stringsFuture = getAvailableGenreSeedsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String[] strings = stringsFuture.get();
+      // Example Only. Never block in production code.
+      final String[] strings = stringsFuture.join();
 
       System.out.println("Length: " + strings.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/follow/CheckCurrentUserFollowsArtistsOrUsersExample.java
+++ b/examples/data/follow/CheckCurrentUserFollowsArtistsOrUsersExample.java
@@ -6,8 +6,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.follow.CheckCurrentUserFollowsArtistsOrUsersRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class CheckCurrentUserFollowsArtistsOrUsersExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +32,18 @@ public class CheckCurrentUserFollowsArtistsOrUsersExample {
 
   public static void checkCurrentUserFollowsArtistsOrUsers_Async() {
     try {
-      final Future<Boolean[]> booleansFuture = checkCurrentUserFollowsArtistsOrUsersRequest.executeAsync();
+      final CompletableFuture<Boolean[]> booleansFuture = checkCurrentUserFollowsArtistsOrUsersRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Boolean[] booleans = booleansFuture.get();
+      // Example Only. Never block in production code.
+      final Boolean[] booleans = booleansFuture.join();
 
       System.out.println("Length: " + booleans.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/follow/CheckUsersFollowPlaylistExample.java
+++ b/examples/data/follow/CheckUsersFollowPlaylistExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.follow.CheckUsersFollowPlaylistRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class CheckUsersFollowPlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +34,18 @@ public class CheckUsersFollowPlaylistExample {
 
   public static void checkUsersFollowPlaylist_Async() {
     try {
-      final Future<Boolean[]> booleansFuture = checkUsersFollowPlaylistRequest.executeAsync();
+      final CompletableFuture<Boolean[]> booleansFuture = checkUsersFollowPlaylistRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Boolean[] booleans = booleansFuture.get();
+      // Example Only. Never block in production code.
+      final Boolean[] booleans = booleansFuture.join();
 
       System.out.println("Length: " + booleans.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/follow/FollowArtistsOrUsersExample.java
+++ b/examples/data/follow/FollowArtistsOrUsersExample.java
@@ -6,8 +6,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.follow.FollowArtistsOrUsersRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class FollowArtistsOrUsersExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +32,18 @@ public class FollowArtistsOrUsersExample {
 
   public static void followArtistsOrUsers_Async() {
     try {
-      final Future<String> stringFuture = followArtistsOrUsersRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = followArtistsOrUsersRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/follow/FollowPlaylistExample.java
+++ b/examples/data/follow/FollowPlaylistExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.follow.FollowPlaylistRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class FollowPlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +34,18 @@ public class FollowPlaylistExample {
 
   public static void followPlaylist_Async() {
     try {
-      final Future<String> stringFuture = followPlaylistRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = followPlaylistRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/follow/GetUsersFollowedArtistsExample.java
+++ b/examples/data/follow/GetUsersFollowedArtistsExample.java
@@ -8,8 +8,9 @@ import com.wrapper.spotify.model_objects.specification.PagingCursorbased;
 import com.wrapper.spotify.requests.data.follow.GetUsersFollowedArtistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetUsersFollowedArtistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +37,18 @@ public class GetUsersFollowedArtistsExample {
 
   public static void getUsersFollowedArtists_Async() {
     try {
-      final Future<PagingCursorbased<Artist>> pagingCursorbasedFuture = getUsersFollowedArtistsRequest.executeAsync();
+      final CompletableFuture<PagingCursorbased<Artist>> pagingCursorbasedFuture = getUsersFollowedArtistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final PagingCursorbased<Artist> artistPagingCursorbased = pagingCursorbasedFuture.get();
+      // Example Only. Never block in production code.
+      final PagingCursorbased<Artist> artistPagingCursorbased = pagingCursorbasedFuture.join();
 
       System.out.println("Total: " + artistPagingCursorbased.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/follow/UnfollowArtistsOrUsersExample.java
+++ b/examples/data/follow/UnfollowArtistsOrUsersExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.follow.UnfollowArtistsOrUsersRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class UnfollowArtistsOrUsersExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +34,18 @@ public class UnfollowArtistsOrUsersExample {
 
   public static void unfollowArtistsOrUsers_Async() {
     try {
-      final Future<String> stringFuture = unfollowArtistsOrUsersRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = unfollowArtistsOrUsersRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/follow/UnfollowPlaylistExample.java
+++ b/examples/data/follow/UnfollowPlaylistExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.follow.UnfollowPlaylistRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class UnfollowPlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +33,18 @@ public class UnfollowPlaylistExample {
 
   public static void unfollowPlaylist_Async() {
     try {
-      final Future<String> stringFuture = unfollowPlaylistRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = unfollowPlaylistRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/library/CheckUsersSavedAlbumsExample.java
+++ b/examples/data/library/CheckUsersSavedAlbumsExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.library.CheckUsersSavedAlbumsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class CheckUsersSavedAlbumsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -30,15 +31,18 @@ public class CheckUsersSavedAlbumsExample {
 
   public static void checkUsersSavedAlbums_Async() {
     try {
-      final Future<Boolean[]> booleansFuture = checkUsersSavedAlbumsRequest.executeAsync();
+      final CompletableFuture<Boolean[]> booleansFuture = checkUsersSavedAlbumsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Boolean[] booleans = booleansFuture.get();
+      // Example Only. Never block in production code.
+      final Boolean[] booleans = booleansFuture.join();
 
       System.out.println("Length: " + booleans.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/library/CheckUsersSavedTracksExample.java
+++ b/examples/data/library/CheckUsersSavedTracksExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.library.CheckUsersSavedTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class CheckUsersSavedTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -30,15 +31,18 @@ public class CheckUsersSavedTracksExample {
 
   public static void checkUsersSavedTracks_Async() {
     try {
-      final Future<Boolean[]> booleansFuture = checkUsersSavedTracksRequest.executeAsync();
+      final CompletableFuture<Boolean[]> booleansFuture = checkUsersSavedTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Boolean[] booleans = booleansFuture.get();
+      // Example Only. Never block in production code.
+      final Boolean[] booleans = booleansFuture.join();
 
       System.out.println("Length: " + booleans.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/library/GetCurrentUsersSavedAlbumsExample.java
+++ b/examples/data/library/GetCurrentUsersSavedAlbumsExample.java
@@ -1,6 +1,5 @@
 package data.library;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Paging;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.SavedAlbum;
 import com.wrapper.spotify.requests.data.library.GetCurrentUsersSavedAlbumsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetCurrentUsersSavedAlbumsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +36,18 @@ public class GetCurrentUsersSavedAlbumsExample {
 
   public static void getCurrentUsersSavedAlbums_Async() {
     try {
-      final Future<Paging<SavedAlbum>> pagingFuture = getCurrentUsersSavedAlbumsRequest.executeAsync();
+      final CompletableFuture<Paging<SavedAlbum>> pagingFuture = getCurrentUsersSavedAlbumsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<SavedAlbum> savedAlbumPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<SavedAlbum> savedAlbumPaging = pagingFuture.join();
 
       System.out.println("Total: " + savedAlbumPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/library/GetUsersSavedTracksExample.java
+++ b/examples/data/library/GetUsersSavedTracksExample.java
@@ -1,6 +1,5 @@
 package data.library;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Paging;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.SavedTrack;
 import com.wrapper.spotify.requests.data.library.GetUsersSavedTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetUsersSavedTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -35,15 +35,18 @@ public class GetUsersSavedTracksExample {
 
   public static void getUsersSavedTracks_Async() {
     try {
-      final Future<Paging<SavedTrack>> pagingFuture = getUsersSavedTracksRequest.executeAsync();
+      final CompletableFuture<Paging<SavedTrack>> pagingFuture = getUsersSavedTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<SavedTrack> savedTrackPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<SavedTrack> savedTrackPaging = pagingFuture.join();
 
       System.out.println("Total: " + savedTrackPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/library/RemoveAlbumsForCurrentUserExample.java
+++ b/examples/data/library/RemoveAlbumsForCurrentUserExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.library.RemoveAlbumsForCurrentUserRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class RemoveAlbumsForCurrentUserExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +32,18 @@ public class RemoveAlbumsForCurrentUserExample {
 
   public static void removeAlbumsForCurrentUser_Async() {
     try {
-      final Future<String> stringFuture = removeAlbumsForCurrentUserRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = removeAlbumsForCurrentUserRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/library/RemoveUsersSavedTracksExample.java
+++ b/examples/data/library/RemoveUsersSavedTracksExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.library.RemoveUsersSavedTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class RemoveUsersSavedTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +32,18 @@ public class RemoveUsersSavedTracksExample {
 
   public static void removeUsersSavedTracks_Async() {
     try {
-      final Future<String> stringFuture = removeUsersSavedTracksRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = removeUsersSavedTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/library/SaveAlbumsForCurrentUserExample.java
+++ b/examples/data/library/SaveAlbumsForCurrentUserExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.library.SaveAlbumsForCurrentUserRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class SaveAlbumsForCurrentUserExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +32,18 @@ public class SaveAlbumsForCurrentUserExample {
 
   public static void saveAlbumsForCurrentUser_Async() {
     try {
-      final Future<String> stringFuture = saveAlbumsForCurrentUserRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = saveAlbumsForCurrentUserRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/library/SaveTracksForUserExample.java
+++ b/examples/data/library/SaveTracksForUserExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.library.SaveTracksForUserRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class SaveTracksForUserExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -30,15 +31,18 @@ public class SaveTracksForUserExample {
 
   public static void saveTracksForUser_Async() {
     try {
-      final Future<String> stringFuture = saveTracksForUserRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = saveTracksForUserRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/personalization/GetUsersTopArtistsAndTracksExample.java
+++ b/examples/data/personalization/GetUsersTopArtistsAndTracksExample.java
@@ -8,8 +8,9 @@ import com.wrapper.spotify.model_objects.specification.Paging;
 import com.wrapper.spotify.requests.data.personalization.GetUsersTopArtistsAndTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetUsersTopArtistsAndTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -38,15 +39,18 @@ public class GetUsersTopArtistsAndTracksExample {
 
   public static void getUsersTopArtistsAndTracks_Async() {
     try {
-      final Future<Paging<Artist>> pagingFuture = getUsersTopArtistsAndTracksRequest.executeAsync();
+      final CompletableFuture<Paging<Artist>> pagingFuture = getUsersTopArtistsAndTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<Artist> artistPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<Artist> artistPaging = pagingFuture.join();
 
       System.out.println("Total: " + artistPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/personalization/simplified/GetUsersTopArtistsExample.java
+++ b/examples/data/personalization/simplified/GetUsersTopArtistsExample.java
@@ -7,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.Paging;
 import com.wrapper.spotify.requests.data.personalization.simplified.GetUsersTopArtistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetUsersTopArtistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -34,15 +35,18 @@ public class GetUsersTopArtistsExample {
 
   public static void getUsersTopArtists_Async() {
     try {
-      final Future<Paging<Artist>> pagingFuture = getUsersTopArtistsRequest.executeAsync();
+      final CompletableFuture<Paging<Artist>> pagingFuture = getUsersTopArtistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<Artist> artistPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<Artist> artistPaging = pagingFuture.join();
 
       System.out.println("Total: " + artistPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/personalization/simplified/GetUsersTopTracksExample.java
+++ b/examples/data/personalization/simplified/GetUsersTopTracksExample.java
@@ -7,8 +7,7 @@ import com.wrapper.spotify.model_objects.specification.Track;
 import com.wrapper.spotify.requests.data.personalization.simplified.GetUsersTopTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class GetUsersTopTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -34,15 +33,18 @@ public class GetUsersTopTracksExample {
 
   public static void getUsersTopTracks_Async() {
     try {
-      final Future<Paging<Track>> pagingFuture = getUsersTopTracksRequest.executeAsync();
+      final CompletableFuture<Paging<Track>> pagingFuture = getUsersTopTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<Track> trackPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<Track> trackPaging = pagingFuture.join();
 
       System.out.println("Total: " + trackPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/GetCurrentUsersRecentlyPlayedTracksExample.java
+++ b/examples/data/player/GetCurrentUsersRecentlyPlayedTracksExample.java
@@ -7,9 +7,9 @@ import com.wrapper.spotify.model_objects.specification.PlayHistory;
 import com.wrapper.spotify.requests.data.player.GetCurrentUsersRecentlyPlayedTracksRequest;
 
 import java.io.IOException;
-import java.util.Date;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetCurrentUsersRecentlyPlayedTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +36,18 @@ public class GetCurrentUsersRecentlyPlayedTracksExample {
 
   public static void getCurrentUsersRecentlyPlayedTracks_Async() {
     try {
-      final Future<PagingCursorbased<PlayHistory>> pagingCursorbasedFuture = getCurrentUsersRecentlyPlayedTracksRequest.executeAsync();
+      final CompletableFuture<PagingCursorbased<PlayHistory>> pagingCursorbasedFuture = getCurrentUsersRecentlyPlayedTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final PagingCursorbased<PlayHistory> playHistoryPagingCursorbased = pagingCursorbasedFuture.get();
+      // Example Only. Never block in production code.
+      final PagingCursorbased<PlayHistory> playHistoryPagingCursorbased = pagingCursorbasedFuture.join();
 
       System.out.println("Total: " + playHistoryPagingCursorbased.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/GetInformationAboutUsersCurrentPlaybackExample.java
+++ b/examples/data/player/GetInformationAboutUsersCurrentPlaybackExample.java
@@ -1,14 +1,14 @@
 package data.player;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.miscellaneous.CurrentlyPlayingContext;
 import com.wrapper.spotify.requests.data.player.GetInformationAboutUsersCurrentPlaybackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetInformationAboutUsersCurrentPlaybackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +33,18 @@ public class GetInformationAboutUsersCurrentPlaybackExample {
 
   public static void getInformationAboutUsersCurrentPlayback_Async() {
     try {
-      final Future<CurrentlyPlayingContext> currentlyPlayingContextFuture = getInformationAboutUsersCurrentPlaybackRequest.executeAsync();
+      final CompletableFuture<CurrentlyPlayingContext> currentlyPlayingContextFuture = getInformationAboutUsersCurrentPlaybackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final CurrentlyPlayingContext currentlyPlayingContext = currentlyPlayingContextFuture.get();
+      // Example Only. Never block in production code.
+      final CurrentlyPlayingContext currentlyPlayingContext = currentlyPlayingContextFuture.join();
 
       System.out.println("Timestamp: " + currentlyPlayingContext.getTimestamp());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/GetUsersAvailableDevicesExample.java
+++ b/examples/data/player/GetUsersAvailableDevicesExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.miscellaneous.Device;
 import com.wrapper.spotify.requests.data.player.GetUsersAvailableDevicesRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetUsersAvailableDevicesExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +32,18 @@ public class GetUsersAvailableDevicesExample {
 
   public static void getUsersAvailableDevices_Async() {
     try {
-      final Future<Device[]> devicesFuture = getUsersAvailableDevicesRequest.executeAsync();
+      final CompletableFuture<Device[]> devicesFuture = getUsersAvailableDevicesRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Device[] devices = devicesFuture.get();
+      // Example Only. Never block in production code.
+      final Device[] devices = devicesFuture.join();
 
       System.out.println("Length: " + devices.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/GetUsersCurrentlyPlayingTrackExample.java
+++ b/examples/data/player/GetUsersCurrentlyPlayingTrackExample.java
@@ -1,14 +1,14 @@
 package data.player;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.miscellaneous.CurrentlyPlaying;
 import com.wrapper.spotify.requests.data.player.GetUsersCurrentlyPlayingTrackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetUsersCurrentlyPlayingTrackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +33,18 @@ public class GetUsersCurrentlyPlayingTrackExample {
 
   public static void getUsersCurrentlyPlayingTrack_Async() {
     try {
-      final Future<CurrentlyPlaying> currentlyPlayingFuture = getUsersCurrentlyPlayingTrackRequest.executeAsync();
+      final CompletableFuture<CurrentlyPlaying> currentlyPlayingFuture = getUsersCurrentlyPlayingTrackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final CurrentlyPlaying currentlyPlaying = currentlyPlayingFuture.get();
+      // Example Only. Never block in production code.
+      final CurrentlyPlaying currentlyPlaying = currentlyPlayingFuture.join();
 
       System.out.println("Timestamp: " + currentlyPlaying.getTimestamp());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/PauseUsersPlaybackExample.java
+++ b/examples/data/player/PauseUsersPlaybackExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.PauseUsersPlaybackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class PauseUsersPlaybackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -30,15 +31,18 @@ public class PauseUsersPlaybackExample {
 
   public static void pauseUsersPlayback_Async() {
     try {
-      final Future<String> stringFuture = pauseUsersPlaybackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = pauseUsersPlaybackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/SeekToPositionInCurrentlyPlayingTrackExample.java
+++ b/examples/data/player/SeekToPositionInCurrentlyPlayingTrackExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.SeekToPositionInCurrentlyPlayingTrackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class SeekToPositionInCurrentlyPlayingTrackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +33,18 @@ public class SeekToPositionInCurrentlyPlayingTrackExample {
 
   public static void seekToPositionInCurrentlyPlayingTrack_Async() {
     try {
-      final Future<String> stringFuture = seekToPositionInCurrentlyPlayingTrackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = seekToPositionInCurrentlyPlayingTrackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/SetRepeatModeOnUsersPlaybackExample.java
+++ b/examples/data/player/SetRepeatModeOnUsersPlaybackExample.java
@@ -5,8 +5,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.SetRepeatModeOnUsersPlaybackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class SetRepeatModeOnUsersPlaybackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +31,18 @@ public class SetRepeatModeOnUsersPlaybackExample {
 
   public static void setRepeatModeOnUsersPlayback_Async() {
     try {
-      final Future<String> stringFuture = setRepeatModeOnUsersPlaybackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = setRepeatModeOnUsersPlaybackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/SetVolumeForUsersPlaybackExample.java
+++ b/examples/data/player/SetVolumeForUsersPlaybackExample.java
@@ -5,8 +5,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.SetVolumeForUsersPlaybackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class SetVolumeForUsersPlaybackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +31,18 @@ public class SetVolumeForUsersPlaybackExample {
 
   public static void setVolumeForUsersPlayback_Async() {
     try {
-      final Future<String> stringFuture = setVolumeForUsersPlaybackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = setVolumeForUsersPlaybackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/SkipUsersPlaybackToNextTrackExample.java
+++ b/examples/data/player/SkipUsersPlaybackToNextTrackExample.java
@@ -5,8 +5,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.SkipUsersPlaybackToNextTrackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class SkipUsersPlaybackToNextTrackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +30,18 @@ public class SkipUsersPlaybackToNextTrackExample {
 
   public static void skipUsersPlaybackToNextTrack_Async() {
     try {
-      final Future<String> stringFuture = skipUsersPlaybackToNextTrackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = skipUsersPlaybackToNextTrackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/SkipUsersPlaybackToPreviousTrackExample.java
+++ b/examples/data/player/SkipUsersPlaybackToPreviousTrackExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.SkipUsersPlaybackToPreviousTrackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class SkipUsersPlaybackToPreviousTrackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +32,18 @@ public class SkipUsersPlaybackToPreviousTrackExample {
 
   public static void skipUsersPlaybackToPreviousTrack_Async() {
     try {
-      final Future<String> stringFuture = skipUsersPlaybackToPreviousTrackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = skipUsersPlaybackToPreviousTrackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/StartResumeUsersPlaybackExample.java
+++ b/examples/data/player/StartResumeUsersPlaybackExample.java
@@ -6,8 +6,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.StartResumeUsersPlaybackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class StartResumeUsersPlaybackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +35,18 @@ public class StartResumeUsersPlaybackExample {
 
   public static void startResumeUsersPlayback_Async() {
     try {
-      final Future<String> stringFuture = startResumeUsersPlaybackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = startResumeUsersPlaybackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/ToggleShuffleForUsersPlaybackExample.java
+++ b/examples/data/player/ToggleShuffleForUsersPlaybackExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.ToggleShuffleForUsersPlaybackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class ToggleShuffleForUsersPlaybackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +33,18 @@ public class ToggleShuffleForUsersPlaybackExample {
 
   public static void toggleShuffleForUsersPlayback_Async() {
     try {
-      final Future<String> stringFuture = toggleShuffleForUsersPlaybackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = toggleShuffleForUsersPlaybackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/player/TransferUsersPlaybackExample.java
+++ b/examples/data/player/TransferUsersPlaybackExample.java
@@ -7,8 +7,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.player.TransferUsersPlaybackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class TransferUsersPlaybackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -34,15 +35,18 @@ public class TransferUsersPlaybackExample {
 
   public static void transferUsersPlayback_Async() {
     try {
-      final Future<String> stringFuture = transferUsersPlaybackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = transferUsersPlaybackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/AddTracksToPlaylistExample.java
+++ b/examples/data/playlists/AddTracksToPlaylistExample.java
@@ -6,8 +6,7 @@ import com.wrapper.spotify.model_objects.special.SnapshotResult;
 import com.wrapper.spotify.requests.data.playlists.AddTracksToPlaylistRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class AddTracksToPlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -34,15 +33,18 @@ public class AddTracksToPlaylistExample {
 
   public static void addTracksToPlaylist_Async() {
     try {
-      final Future<SnapshotResult> snapshotResultFuture = addTracksToPlaylistRequest.executeAsync();
+      final CompletableFuture<SnapshotResult> snapshotResultFuture = addTracksToPlaylistRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final SnapshotResult snapshotResult = snapshotResultFuture.get();
+      // Example Only. Never block in production code.
+      final SnapshotResult snapshotResult = snapshotResultFuture.join();
 
       System.out.println("Snapshot ID: " + snapshotResult.getSnapshotId());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/ChangePlaylistsDetailsExample.java
+++ b/examples/data/playlists/ChangePlaylistsDetailsExample.java
@@ -5,8 +5,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.playlists.ChangePlaylistsDetailsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class ChangePlaylistsDetailsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -35,15 +36,18 @@ public class ChangePlaylistsDetailsExample {
 
   public static void changePlaylistsDetails_Async() {
     try {
-      final Future<String> stringFuture = changePlaylistsDetailsRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = changePlaylistsDetailsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/CreatePlaylistExample.java
+++ b/examples/data/playlists/CreatePlaylistExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.Playlist;
 import com.wrapper.spotify.requests.data.playlists.CreatePlaylistRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class CreatePlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -35,15 +36,18 @@ public class CreatePlaylistExample {
 
   public static void createPlaylist_Async() {
     try {
-      final Future<Playlist> playlistFuture = createPlaylistRequest.executeAsync();
+      final CompletableFuture<Playlist> playlistFuture = createPlaylistRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Playlist playlist = playlistFuture.get();
+      // Example Only. Never block in production code.
+      final Playlist playlist = playlistFuture.join();
 
       System.out.println("Name: " + playlist.getName());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/GetListOfCurrentUsersPlaylistsExample.java
+++ b/examples/data/playlists/GetListOfCurrentUsersPlaylistsExample.java
@@ -7,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.PlaylistSimplified;
 import com.wrapper.spotify.requests.data.playlists.GetListOfCurrentUsersPlaylistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetListOfCurrentUsersPlaylistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -34,15 +35,18 @@ public class GetListOfCurrentUsersPlaylistsExample {
 
   public static void getListOfCurrentUsersPlaylists_Async() {
     try {
-      final Future<Paging<PlaylistSimplified>> pagingFuture = getListOfCurrentUsersPlaylistsRequest.executeAsync();
+      final CompletableFuture<Paging<PlaylistSimplified>> pagingFuture = getListOfCurrentUsersPlaylistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<PlaylistSimplified> playlistSimplifiedPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<PlaylistSimplified> playlistSimplifiedPaging = pagingFuture.join();
 
       System.out.println("Total: " + playlistSimplifiedPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/GetListOfUsersPlaylistsExample.java
+++ b/examples/data/playlists/GetListOfUsersPlaylistsExample.java
@@ -7,8 +7,7 @@ import com.wrapper.spotify.model_objects.specification.PlaylistSimplified;
 import com.wrapper.spotify.requests.data.playlists.GetListOfUsersPlaylistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class GetListOfUsersPlaylistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -35,15 +34,18 @@ public class GetListOfUsersPlaylistsExample {
 
   public static void getListOfUsersPlaylists_Async() {
     try {
-      final Future<Paging<PlaylistSimplified>> pagingFuture = getListOfUsersPlaylistsRequest.executeAsync();
+      final CompletableFuture<Paging<PlaylistSimplified>> pagingFuture = getListOfUsersPlaylistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<PlaylistSimplified> playlistSimplifiedPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<PlaylistSimplified> playlistSimplifiedPaging = pagingFuture.join();
 
       System.out.println("Total: " + playlistSimplifiedPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/GetPlaylistCoverImageExample.java
+++ b/examples/data/playlists/GetPlaylistCoverImageExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.Image;
 import com.wrapper.spotify.requests.data.playlists.GetPlaylistCoverImageRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetPlaylistCoverImageExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +33,18 @@ public class GetPlaylistCoverImageExample {
 
   public static void getPlaylistCoverImage_Async() {
     try {
-      final Future<Image[]> imagesFuture = getPlaylistCoverImageRequest.executeAsync();
+      final CompletableFuture<Image[]> imagesFuture = getPlaylistCoverImageRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Image[] images = imagesFuture.get();
+      // Example Only. Never block in production code.
+      final Image[] images = imagesFuture.join();
 
       System.out.println("Length: " + images.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/GetPlaylistExample.java
+++ b/examples/data/playlists/GetPlaylistExample.java
@@ -1,14 +1,14 @@
 package data.playlists;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Playlist;
 import com.wrapper.spotify.requests.data.playlists.GetPlaylistRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetPlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -34,15 +34,18 @@ public class GetPlaylistExample {
 
   public static void getPlaylist_Async() {
     try {
-      final Future<Playlist> playlistFuture = getPlaylistRequest.executeAsync();
+      final CompletableFuture<Playlist> playlistFuture = getPlaylistRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Playlist playlist = playlistFuture.get();
+      // Example Only. Never block in production code.
+      final Playlist playlist = playlistFuture.join();
 
       System.out.println("Name: " + playlist.getName());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/GetPlaylistsTracksExample.java
+++ b/examples/data/playlists/GetPlaylistsTracksExample.java
@@ -1,6 +1,5 @@
 package data.playlists;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Paging;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.PlaylistTrack;
 import com.wrapper.spotify.requests.data.playlists.GetPlaylistsTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetPlaylistsTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -38,15 +38,18 @@ public class GetPlaylistsTracksExample {
 
   public static void getPlaylistsTracks_Async() {
     try {
-      final Future<Paging<PlaylistTrack>> pagingFuture = getPlaylistsTracksRequest.executeAsync();
+      final CompletableFuture<Paging<PlaylistTrack>> pagingFuture = getPlaylistsTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<PlaylistTrack> playlistTrackPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<PlaylistTrack> playlistTrackPaging = pagingFuture.join();
 
       System.out.println("Total: " + playlistTrackPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/RemoveTracksFromPlaylistExample.java
+++ b/examples/data/playlists/RemoveTracksFromPlaylistExample.java
@@ -8,8 +8,7 @@ import com.wrapper.spotify.model_objects.special.SnapshotResult;
 import com.wrapper.spotify.requests.data.playlists.RemoveTracksFromPlaylistRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class RemoveTracksFromPlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -37,15 +36,18 @@ public class RemoveTracksFromPlaylistExample {
 
   public static void removeTracksFromPlaylist_Async() {
     try {
-      final Future<SnapshotResult> snapshotResultFuture = removeTracksFromPlaylistRequest.executeAsync();
+      final CompletableFuture<SnapshotResult> snapshotResultFuture = removeTracksFromPlaylistRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final SnapshotResult snapshotResult = snapshotResultFuture.get();
+      // Example Only. Never block in production code.
+      final SnapshotResult snapshotResult = snapshotResultFuture.join();
 
       System.out.println("Snapshot ID: " + snapshotResult.getSnapshotId());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/ReorderPlaylistsTracksExample.java
+++ b/examples/data/playlists/ReorderPlaylistsTracksExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.special.SnapshotResult;
 import com.wrapper.spotify.requests.data.playlists.ReorderPlaylistsTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class ReorderPlaylistsTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -37,15 +38,18 @@ public class ReorderPlaylistsTracksExample {
 
   public static void reorderPlaylistsTracks_Async() {
     try {
-      final Future<SnapshotResult> snapshotResultFuture = reorderPlaylistsTracksRequest.executeAsync();
+      final CompletableFuture<SnapshotResult> snapshotResultFuture = reorderPlaylistsTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final SnapshotResult snapshotResult = snapshotResultFuture.get();
+      // Example Only. Never block in production code.
+      final SnapshotResult snapshotResult = snapshotResultFuture.join();
 
       System.out.println("Snapshot ID: " + snapshotResult.getSnapshotId());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/ReplacePlaylistsTracksExample.java
+++ b/examples/data/playlists/ReplacePlaylistsTracksExample.java
@@ -5,8 +5,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.playlists.ReplacePlaylistsTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class ReplacePlaylistsTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +31,18 @@ public class ReplacePlaylistsTracksExample {
 
   public static void replacePlaylistsTracks_Async() {
     try {
-      final Future<String> stringFuture = replacePlaylistsTracksRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = replacePlaylistsTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/playlists/UploadCustomPlaylistCoverImageExample.java
+++ b/examples/data/playlists/UploadCustomPlaylistCoverImageExample.java
@@ -5,8 +5,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.requests.data.playlists.UploadCustomPlaylistCoverImageRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class UploadCustomPlaylistCoverImageExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +31,18 @@ public class UploadCustomPlaylistCoverImageExample {
 
   public static void uploadCustomPlaylistCoverImage_Async() {
     try {
-      final Future<String> stringFuture = uploadCustomPlaylistCoverImageRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = uploadCustomPlaylistCoverImageRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final String string = stringFuture.get();
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
 
       System.out.println("Null: " + string);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/search/SearchItemExample.java
+++ b/examples/data/search/SearchItemExample.java
@@ -1,6 +1,5 @@
 package data.search;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.enums.ModelObjectType;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.special.SearchResult;
 import com.wrapper.spotify.requests.data.search.SearchItemRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class SearchItemExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -37,15 +37,18 @@ public class SearchItemExample {
 
   public static void searchItem_Async() {
     try {
-      final Future<SearchResult> searchResultFuture = searchItemRequest.executeAsync();
+      final CompletableFuture<SearchResult> searchResultFuture = searchItemRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final SearchResult searchResult = searchResultFuture.get();
+      // Example Only. Never block in production code.
+      final SearchResult searchResult = searchResultFuture.join();
 
       System.out.println("Total tracks: " + searchResult.getTracks().getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/search/simplified/SearchAlbumsExample.java
+++ b/examples/data/search/simplified/SearchAlbumsExample.java
@@ -1,6 +1,5 @@
 package data.search.simplified;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.AlbumSimplified;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.Paging;
 import com.wrapper.spotify.requests.data.search.simplified.SearchAlbumsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class SearchAlbumsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +36,18 @@ public class SearchAlbumsExample {
 
   public static void searchAlbums_Async() {
     try {
-      final Future<Paging<AlbumSimplified>> pagingFuture = searchAlbumsRequest.executeAsync();
+      final CompletableFuture<Paging<AlbumSimplified>> pagingFuture = searchAlbumsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<AlbumSimplified> albumSimplifiedPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<AlbumSimplified> albumSimplifiedPaging = pagingFuture.join();
 
       System.out.println("Total: " + albumSimplifiedPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/search/simplified/SearchArtistsExample.java
+++ b/examples/data/search/simplified/SearchArtistsExample.java
@@ -1,6 +1,5 @@
 package data.search.simplified;
 
-import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.Artist;
@@ -8,8 +7,9 @@ import com.wrapper.spotify.model_objects.specification.Paging;
 import com.wrapper.spotify.requests.data.search.simplified.SearchArtistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class SearchArtistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +36,18 @@ public class SearchArtistsExample {
 
   public static void searchArtists_Async() {
     try {
-      final Future<Paging<Artist>> pagingFuture = searchArtistsRequest.executeAsync();
+      final CompletableFuture<Paging<Artist>> pagingFuture = searchArtistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<Artist> artistPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<Artist> artistPaging = pagingFuture.join();
 
       System.out.println("Total: " + artistPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/search/simplified/SearchPlaylistsExample.java
+++ b/examples/data/search/simplified/SearchPlaylistsExample.java
@@ -8,8 +8,7 @@ import com.wrapper.spotify.model_objects.specification.PlaylistSimplified;
 import com.wrapper.spotify.requests.data.search.simplified.SearchPlaylistsRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class SearchPlaylistsExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +35,18 @@ public class SearchPlaylistsExample {
 
   public static void searchPlaylists_Async() {
     try {
-      final Future<Paging<PlaylistSimplified>> pagingFuture = searchPlaylistsRequest.executeAsync();
+      final CompletableFuture<Paging<PlaylistSimplified>> pagingFuture = searchPlaylistsRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<PlaylistSimplified> playlistSimplifiedPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<PlaylistSimplified> playlistSimplifiedPaging = pagingFuture.join();
 
       System.out.println("Total: " + playlistSimplifiedPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/search/simplified/SearchTracksExample.java
+++ b/examples/data/search/simplified/SearchTracksExample.java
@@ -8,8 +8,7 @@ import com.wrapper.spotify.model_objects.specification.Track;
 import com.wrapper.spotify.requests.data.search.simplified.SearchTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class SearchTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -36,15 +35,18 @@ public class SearchTracksExample {
 
   public static void searchTracks_Async() {
     try {
-      final Future<Paging<Track>> pagingFuture = searchTracksRequest.executeAsync();
+      final CompletableFuture<Paging<Track>> pagingFuture = searchTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Paging<Track> trackPaging = pagingFuture.get();
+      // Example Only. Never block in production code.
+      final Paging<Track> trackPaging = pagingFuture.join();
 
       System.out.println("Total: " + trackPaging.getTotal());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/tracks/GetAudioAnalysisForTrackExample.java
+++ b/examples/data/tracks/GetAudioAnalysisForTrackExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.miscellaneous.AudioAnalysis;
 import com.wrapper.spotify.requests.data.tracks.GetAudioAnalysisForTrackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetAudioAnalysisForTrackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +33,18 @@ public class GetAudioAnalysisForTrackExample {
 
   public static void getAudioAnalysisForTrack_Async() {
     try {
-      final Future<AudioAnalysis> audioAnalysisFuture = getAudioAnalysisForTrackRequest.executeAsync();
+      final CompletableFuture<AudioAnalysis> audioAnalysisFuture = getAudioAnalysisForTrackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final AudioAnalysis audioAnalysis = audioAnalysisFuture.get();
+      // Example Only. Never block in production code.
+      final AudioAnalysis audioAnalysis = audioAnalysisFuture.join();
 
       System.out.println("Track duration: " + audioAnalysis.getTrack().getDuration());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/tracks/GetAudioFeaturesForSeveralTracksExample.java
+++ b/examples/data/tracks/GetAudioFeaturesForSeveralTracksExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.AudioFeatures;
 import com.wrapper.spotify.requests.data.tracks.GetAudioFeaturesForSeveralTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetAudioFeaturesForSeveralTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +33,18 @@ public class GetAudioFeaturesForSeveralTracksExample {
 
   public static void getAudioFeaturesForSeveralTracks_Async() {
     try {
-      final Future<AudioFeatures[]> audioFeaturesFuture = getAudioFeaturesForSeveralTracksRequest.executeAsync();
+      final CompletableFuture<AudioFeatures[]> audioFeaturesFuture = getAudioFeaturesForSeveralTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final AudioFeatures[] audioFeatures = audioFeaturesFuture.get();
+      // Example Only. Never block in production code.
+      final AudioFeatures[] audioFeatures = audioFeaturesFuture.join();
 
       System.out.println("Length: " + audioFeatures.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/tracks/GetAudioFeaturesForTrackExample.java
+++ b/examples/data/tracks/GetAudioFeaturesForTrackExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.AudioFeatures;
 import com.wrapper.spotify.requests.data.tracks.GetAudioFeaturesForTrackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetAudioFeaturesForTrackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -32,15 +33,18 @@ public class GetAudioFeaturesForTrackExample {
 
   public static void getAudioFeaturesForTrack_Async() {
     try {
-      final Future<AudioFeatures> audioFeaturesFuture = getAudioFeaturesForTrackRequest.executeAsync();
+      final CompletableFuture<AudioFeatures> audioFeaturesFuture = getAudioFeaturesForTrackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final AudioFeatures audioFeatures = audioFeaturesFuture.get();
+      // Example Only. Never block in production code.
+      final AudioFeatures audioFeatures = audioFeaturesFuture.join();
 
       System.out.println("ID: " + audioFeatures.getId());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/tracks/GetSeveralTracksExample.java
+++ b/examples/data/tracks/GetSeveralTracksExample.java
@@ -7,8 +7,7 @@ import com.wrapper.spotify.model_objects.specification.Track;
 import com.wrapper.spotify.requests.data.tracks.GetSeveralTracksRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class GetSeveralTracksExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +32,18 @@ public class GetSeveralTracksExample {
 
   public static void getSeveralTracks_Async() {
     try {
-      final Future<Track[]> tracksFuture = getSeveralTracksRequest.executeAsync();
+      final CompletableFuture<Track[]> tracksFuture = getSeveralTracksRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Track[] tracks = tracksFuture.get();
+      // Example Only. Never block in production code.
+      final Track[] tracks = tracksFuture.join();
 
       System.out.println("Length: " + tracks.length);
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/tracks/GetTrackExample.java
+++ b/examples/data/tracks/GetTrackExample.java
@@ -7,8 +7,7 @@ import com.wrapper.spotify.model_objects.specification.Track;
 import com.wrapper.spotify.requests.data.tracks.GetTrackRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 public class GetTrackExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -33,15 +32,18 @@ public class GetTrackExample {
 
   public static void getTrack_Async() {
     try {
-      final Future<Track> trackFuture = getTrackRequest.executeAsync();
+      final CompletableFuture<Track> trackFuture = getTrackRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final Track track = trackFuture.get();
+      // Example Only. Never block in production code.
+      final Track track = trackFuture.join();
 
       System.out.println("Name: " + track.getName());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/users_profile/GetCurrentUsersProfileExample.java
+++ b/examples/data/users_profile/GetCurrentUsersProfileExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.User;
 import com.wrapper.spotify.requests.data.users_profile.GetCurrentUsersProfileRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetCurrentUsersProfileExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -30,15 +31,18 @@ public class GetCurrentUsersProfileExample {
 
   public static void getCurrentUsersProfile_Async() {
     try {
-      final Future<User> userFuture = getCurrentUsersProfileRequest.executeAsync();
+      final CompletableFuture<User> userFuture = getCurrentUsersProfileRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final User user = userFuture.get();
+      // Example Only. Never block in production code.
+      final User user = userFuture.join();
 
       System.out.println("Display name: " + user.getDisplayName());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/examples/data/users_profile/GetUsersProfileExample.java
+++ b/examples/data/users_profile/GetUsersProfileExample.java
@@ -6,8 +6,9 @@ import com.wrapper.spotify.model_objects.specification.User;
 import com.wrapper.spotify.requests.data.users_profile.GetUsersProfileRequest;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GetUsersProfileExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
@@ -31,15 +32,18 @@ public class GetUsersProfileExample {
 
   public static void getUsersProfile_Async() {
     try {
-      final Future<User> userFuture = getUsersProfileRequest.executeAsync();
+      final CompletableFuture<User> userFuture = getUsersProfileRequest.executeAsync();
 
-      // ...
+      // Thread free to do other tasks...
 
-      final User user = userFuture.get();
+      // Example Only. Never block in production code.
+      final User user = userFuture.join();
 
       System.out.println("Display name: " + user.getDisplayName());
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (CompletionException e) {
       System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
     }
   }
 }

--- a/src/main/java/com/wrapper/spotify/SpotifyApiThreading.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyApiThreading.java
@@ -1,16 +1,26 @@
 package com.wrapper.spotify;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 public class SpotifyApiThreading {
 
   public static final ExecutorService THREADPOOL = Executors.newCachedThreadPool();
 
-  public static <T> Future<T> executeAsync(final Callable<T> callable) {
-    return SpotifyApiThreading.THREADPOOL.submit(callable);
+  public static <T> CompletableFuture<T> executeAsync(final Callable<T> callable) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+
+    SpotifyApiThreading.THREADPOOL.execute(() -> {
+      try {
+        future.complete(callable.call());
+      } catch (Exception e) {
+        future.completeExceptionally(e);
+      }
+    });
+
+    return future;
   }
 
 }

--- a/src/main/java/com/wrapper/spotify/requests/AbstractRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/AbstractRequest.java
@@ -22,7 +22,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -68,9 +68,9 @@ public abstract class AbstractRequest<T> implements IRequest<T> {
   /**
    * Get something asynchronously.
    *
-   * @return A {@link Future} for a generic.
+   * @return A {@link CompletableFuture} for a generic.
    */
-  public Future<T> executeAsync() {
+  public CompletableFuture<T> executeAsync() {
     return SpotifyApiThreading.executeAsync(
             this::execute);
   }

--- a/src/main/java/com/wrapper/spotify/requests/IRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/IRequest.java
@@ -11,7 +11,7 @@ import org.apache.http.entity.ContentType;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 public interface IRequest<T> {
 
@@ -31,7 +31,7 @@ public interface IRequest<T> {
           IOException,
           SpotifyWebApiException;
 
-  Future<T> executeAsync();
+  CompletableFuture<T> executeAsync();
 
   String getJson() throws
           IOException,


### PR DESCRIPTION
Discovered and subsequently used this project the other day for playing around with Spotify and noticed that your async functions return Java 5's [Future](https://docs.oracle.com/javase/1.5.0/docs/api/java/util/concurrent/Future.html). Given you dropped support for Java 7 in [3.0.0](https://github.com/thelinmichael/spotify-web-api-java/releases/tag/3.0.0), I saw this as an opportunity to use Java 8's [CompletableFuture](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html).

This change allows users of this library to _properly_ consume it in an asynchronous manner without having to use any blocking calls (i.e. [Future::get](https://docs.oracle.com/javase/1.5.0/docs/api/java/util/concurrent/Future.html#get())).

This modification will cause binary incompatibility.

Given how well this PR is received, I would be interested in addressing asynchronous operations in this library at its core (such as using [httpcomponents-asyncclient](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/index.html)).