### PR TITLE
Setting up CodeCov code coverage for openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
   directories:
   - $HOME/.m2
 after_success:
-  script: "if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; then mvn cobertura:cobertura ; fi"
+  - ./travis/code_cov.sh
 before_deploy:
   - ./travis/before-deploy.sh
   - cp ./travis/.m2.settings.xml $HOME/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - chmod +x /travis/code_cov.sh
 language: java
 matrix:
   include:
@@ -6,7 +8,6 @@ matrix:
       before_install:
         - rm "${JAVA_HOME}/lib/security/cacerts"
         - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
-        - chmod +x /travis/code_cov.sh
     - jdk: openjdk12
     - jdk: oraclejdk12
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
   directories:
   - $HOME/.m2
 after_success:
-  script: "if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; then bash <(curl -s https://codecov.io/bash) ; fi"
+  script: "if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; then mvn cobertura:cobertura ; bash <(curl -s https://codecov.io/bash) ; fi"
 before_deploy:
   - ./travis/before-deploy.sh
   - cp ./travis/.m2.settings.xml $HOME/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
       before_install:
         - rm "${JAVA_HOME}/lib/security/cacerts"
         - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+        - chmod +x /travis/code_cov.sh
     - jdk: openjdk12
     - jdk: oraclejdk12
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - chmod +x /travis/code_cov.sh
+  - chmod +x travis/code_cov.sh
 language: java
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
   directories:
   - $HOME/.m2
 after_success:
-  script: "if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; then bash <(curl -s https://codecov.io/bash); fi"
+  script: "if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; then bash <(curl -s https://codecov.io/bash) ; fi"
 before_deploy:
   - ./travis/before-deploy.sh
   - cp ./travis/.m2.settings.xml $HOME/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
   directories:
   - $HOME/.m2
 after_success:
-  - ./travis/code_cov.sh
+  script: "if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; then mvn cobertura:cobertura ; fi"
 before_deploy:
   - ./travis/before-deploy.sh
   - cp ./travis/.m2.settings.xml $HOME/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,7 @@ notifications:
   email:
     on_success: never
     on_failure: change
+script: "mvn cobertura:cobertura"
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,8 @@ notifications:
   email:
     on_success: never
     on_failure: change
-    env:
-  - ONE=one
-  - TWO=two
-jobs:
-  allow_failures:
-    - if: jdk = oraclejdk9 
-  include:
-      if: jdk = openjdk8
-      script: "mvn cobertura:cobertura"
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+    
+if: jdk = openjdk8
+  script: "mvn cobertura:cobertura"
+  after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
 cache:
   directories:
   - $HOME/.m2
+after_success:
+  script: "if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; then bash <(curl -s https://codecov.io/bash); fi"
 before_deploy:
   - ./travis/before-deploy.sh
   - cp ./travis/.m2.settings.xml $HOME/.m2/settings.xml
@@ -38,4 +40,4 @@ notifications:
     on_success: never
     on_failure: change
     
-script: "if [ '${TRAVIS_JDK_VERSION}' = 'oraclejdk12' ]; then bash <(curl -s https://codecov.io/bash); fi"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
   directories:
   - $HOME/.m2
 after_success:
-  script: "if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; then mvn cobertura:cobertura ; bash <(curl -s https://codecov.io/bash) ; fi"
+  - ./travis/code_cov.sh
 before_deploy:
   - ./travis/before-deploy.sh
   - cp ./travis/.m2.settings.xml $HOME/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,4 @@ notifications:
     on_success: never
     on_failure: change
     
-if: jdk = openjdk8
-  script: "mvn cobertura:cobertura"
-  after_success:
-    - bash <(curl -s https://codecov.io/bash)
+script: "if [ '${TRAVIS_JDK_VERSION}' = 'oraclejdk12' ]; then bash <(curl -s https://codecov.io/bash); fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,15 @@ notifications:
   email:
     on_success: never
     on_failure: change
-script: "mvn cobertura:cobertura"
+    env:
+  - ONE=one
+  - TWO=two
+jobs:
+  allow_failures:
+    - if: jdk = oraclejdk9 
+  include:
+      if: jdk = openjdk8
+      script: "mvn cobertura:cobertura"
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,18 @@
             </activation>
             <build>
                 <plugins>
+                  <plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>cobertura-maven-plugin</artifactId>
+    <version>2.7</version>
+    <configuration>
+        <formats>
+            <format>html</format>
+            <format>xml</format>
+        </formats>
+        <check />
+    </configuration>
+</plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
@@ -190,6 +202,20 @@
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
+                  
+                  <plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>cobertura-maven-plugin</artifactId>
+    <version>2.7</version>
+    <configuration>
+        <formats>
+            <format>html</format>
+            <format>xml</format>
+        </formats>
+        <check />
+    </configuration>
+</plugin>
+                  
                 </plugins>
             </build>
         </profile>

--- a/travis/code_cov.sh
+++ b/travis/code_cov.sh
@@ -1,6 +1,5 @@
 set -ev
-if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]
-  then 
-    mvn cobertura:cobertura 
-    bash <(curl -s https://codecov.io/bash) 
+if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ] then 
+    mvn cobertura:cobertura
+    bash <(curl -s https://codecov.io/bash)
 fi

--- a/travis/code_cov.sh
+++ b/travis/code_cov.sh
@@ -1,5 +1,4 @@
 set -ev
 if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ] then 
-    mvn cobertura:cobertura
-    bash <(curl -s https://codecov.io/bash)
+    mvn cobertura:cobertura ;
 fi

--- a/travis/code_cov.sh
+++ b/travis/code_cov.sh
@@ -1,0 +1,6 @@
+set -ev
+if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; 
+  then 
+    mvn cobertura:cobertura ; 
+    bash <(curl -s https://codecov.io/bash) ; 
+fi

--- a/travis/code_cov.sh
+++ b/travis/code_cov.sh
@@ -1,4 +1,2 @@
 set -ev
-if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ] then 
-    mvn cobertura:cobertura ;
-fi
+if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ] then mvn cobertura:cobertura ; fi

--- a/travis/code_cov.sh
+++ b/travis/code_cov.sh
@@ -1,4 +1,5 @@
 set -ev
 if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ]; then 
   mvn cobertura:cobertura 
+  bash <(curl -s https://codecov.io/bash)
 fi

--- a/travis/code_cov.sh
+++ b/travis/code_cov.sh
@@ -1,2 +1,2 @@
 set -ev
-if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ] then mvn cobertura:cobertura ; fi
+if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ]; then mvn cobertura:cobertura fi

--- a/travis/code_cov.sh
+++ b/travis/code_cov.sh
@@ -1,2 +1,4 @@
 set -ev
-if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ]; then mvn cobertura:cobertura fi
+if [ "${TRAVIS_JDK_VERSION}" = "openjdk8" ]; then 
+  mvn cobertura:cobertura 
+fi

--- a/travis/code_cov.sh
+++ b/travis/code_cov.sh
@@ -1,6 +1,6 @@
 set -ev
-if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]; 
+if [ '${TRAVIS_JDK_VERSION}' = 'openjdk8' ]
   then 
-    mvn cobertura:cobertura ; 
-    bash <(curl -s https://codecov.io/bash) ; 
+    mvn cobertura:cobertura 
+    bash <(curl -s https://codecov.io/bash) 
 fi


### PR DESCRIPTION
###Code coverage using CodeCov
- I set up code coverage for this repository for openjdk8 build. 
- These are my CodeCov results for this repo: [https://codecov.io/gh/mformihir/spotify-web-api-java] which is **~69%**.
- I believe setting up code coverage for this repo can be a great way to measure code quality and it would allow the developers/contributors to focus on where the improvements are possible.
- To keep the changes minimal for now, I used Cobertura and set it up for openjdk8 build. I tried setting up Cobertura for the latest Java versions but it didn't seem to work for me, I can work on that if this Pull Request is approved.

P.S.: I had some issues while setting up CodeCov, Travis CI didn't upload the results to CodeCov, which is why I have a long history of commits for this Pull Request. If that is an issue, I can submit another PR.

Thanks!

