### PR TITLE
Adding the CodeCov results to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 | ------------------ |
 | You **cannot** use this library for Android app development. Have a look at [kaaes/spotify-web-api-android](https://www.github.com/kaaes/spotify-web-api-android) and [Spotify's Android SDK](https://developer.spotify.com/technologies/spotify-android-sdk/) and [see why](https://github.com/thelinmichael/spotify-web-api-java/issues/120#issuecomment-363266591). |
 
-Spotify Web API Java [![Build Status](https://travis-ci.org/thelinmichael/spotify-web-api-java.svg?branch=master)](https://travis-ci.org/thelinmichael/spotify-web-api-java)
+Spotify Web API Java [![Build Status](https://travis-ci.org/thelinmichael/spotify-web-api-java.svg?branch=master)](https://travis-ci.org/thelinmichael/spotify-web-api-java) [![codecov](https://codecov.io/gh/thelinmichael/spotify-web-api-java/branch/develop/graph/badge.svg)](https://codecov.io/gh/thelinmichael/spotify-web-api-java)
 ====================
 
 This is a Java wrapper/client for the [Spotify Web API](https://developer.spotify.com/web-api/).


### PR DESCRIPTION
This change adds the code coverage results of develop branch to **README.md**, which will let the visitors and the current developers see the results directly at the repo's homepage!

Thanks!