### PR TITLE
Add Support for Adding Items to User's Playback Queue 

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ spotifyApi
 
 
 - **Player**
+  - [Add Item to User's Playback Queue](examples/data/player/AddItemToUsersPlaybackQueueExample.java)
   - [Get a User's Available Devices](examples/data/player/GetUsersAvailableDevicesExample.java)
   - [Get Information About The User's Current Playback](examples/data/player/GetInformationAboutUsersCurrentPlaybackExample.java)
   - [Get Current User's Recently Played Tracks](examples/data/player/GetCurrentUsersRecentlyPlayedTracksExample.java)

--- a/examples/data/player/AddItemToUsersPlaybackQueueExample.java
+++ b/examples/data/player/AddItemToUsersPlaybackQueueExample.java
@@ -1,0 +1,53 @@
+package data.player;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import com.wrapper.spotify.SpotifyApi;
+import com.wrapper.spotify.exceptions.SpotifyWebApiException;
+import com.wrapper.spotify.requests.data.player.TransferUsersPlaybackRequest;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class AddItemToUsersPlaybackExample {
+  private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
+  private static final String trackUri = "spotify:track:01iyCAUm8EvOFqVWYJ3dVX"
+
+  private static final SpotifyApi spotifyApi = new SpotifyApi.Builder()
+    .setAccessToken(accessToken)
+    .build();
+
+  AddItemToUsersPlaybackExample addItemToUsersPlaybackRequest = spotifyApi
+    .addItemToUsersPlaybackQueue(trackUri)
+//    .device_id("5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e")
+    .build();
+
+  public static void addItemToUsersPlaybackQueue_Sync() {
+    try {
+      final String string = addItemToUsersPlaybackRequest.execute();
+
+      System.out.println("Null: " + string);
+    } catch (IOException | SpotifyWebApiException e) {
+      System.out.println("Error: " + e.getMessage());
+    }
+  }
+
+  public static void addItemToUsersPlaybackQueue_Async() {
+    try {
+      final CompletableFuture<String> stringFuture = addItemToUsersPlaybackRequest.executeAsync();
+
+      // Thread free to do other tasks...
+
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
+
+      System.out.println("Null: " + string);
+    } catch (CompletionException e) {
+      System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
+    }
+  }
+}

--- a/examples/data/player/AddItemToUsersPlaybackQueueExample.java
+++ b/examples/data/player/AddItemToUsersPlaybackQueueExample.java
@@ -11,22 +11,21 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-public class AddItemToUsersPlaybackExample {
+public class AddItemToUsersPlaybackQueueExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
   private static final String trackUri = "spotify:track:01iyCAUm8EvOFqVWYJ3dVX"
 
   private static final SpotifyApi spotifyApi = new SpotifyApi.Builder()
     .setAccessToken(accessToken)
     .build();
-
-  AddItemToUsersPlaybackExample addItemToUsersPlaybackRequest = spotifyApi
+  private static final AddItemToUsersPlaybackQueueExample addItemToUsersPlaybackQueueRequest = spotifyApi
     .addItemToUsersPlaybackQueue(trackUri)
 //    .device_id("5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e")
     .build();
 
   public static void addItemToUsersPlaybackQueue_Sync() {
     try {
-      final String string = addItemToUsersPlaybackRequest.execute();
+      final String string = addItemToUsersPlaybackQueueRequest.execute();
 
       System.out.println("Null: " + string);
     } catch (IOException | SpotifyWebApiException e) {
@@ -36,7 +35,7 @@ public class AddItemToUsersPlaybackExample {
 
   public static void addItemToUsersPlaybackQueue_Async() {
     try {
-      final CompletableFuture<String> stringFuture = addItemToUsersPlaybackRequest.executeAsync();
+      final CompletableFuture<String> stringFuture = addItemToUsersPlaybackQueueRequest.executeAsync();
 
       // Thread free to do other tasks...
 

--- a/src/main/java/com/wrapper/spotify/SpotifyApi.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyApi.java
@@ -1073,6 +1073,19 @@ public class SpotifyApi {
   }
 
   /**
+   * Add a track or an episode to the end of the user's current playback queue.
+   *
+   * @param uri The uri of the item to add to the queue. Must be a track or an episode uri.
+   * @return A {@link AddItemToUsersPlaybackQueueRequest.Builder}.
+   * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URLs &amp; IDs</a>
+   */
+  public AddItemToUsersPlaybackQueueRequest.Builder addItemToUsersPlaybackQueue(String uri) {
+    return new AddItemToUsersPlaybackQueueRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port)
+      .uri(uri);
+  }
+
+  /**
    * Add tracks to a playlist.
    *
    * @param user_id     The owners username.

--- a/src/main/java/com/wrapper/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequest.java
+++ b/src/main/java/com/wrapper/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequest.java
@@ -1,0 +1,98 @@
+package com.wrapper.spotify.requests.data.player;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.wrapper.spotify.exceptions.SpotifyWebApiException;
+import com.wrapper.spotify.requests.data.AbstractDataRequest;
+import org.apache.http.entity.ContentType;
+
+import java.io.IOException;
+
+/**
+ * Add a track or an episode to the end of the user's current playback queue.
+ */
+@JsonDeserialize(builder = AddItemToUsersPlaybackQueueRequest.Builder.class)
+public class AddItemToUsersPlaybackQueueRequest extends AbstractDataRequest<String> {
+
+  /**
+   * The private {@link AddItemToUsersPlaybackQueueRequest} constructor.
+   *
+   * @param builder A {@link AddItemToUsersPlaybackQueueRequest.Builder}.
+   */
+  private AddItemToUsersPlaybackQueueRequest(final Builder builder){
+    super(builder);
+  }
+
+  /**
+   * Add an item to the user's playback queue.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
+  @Override
+  public String execute() throws
+    IOException,
+    SpotifyWebApiException {
+    return postJson();
+  }
+
+  /**
+   * Builder class for building a {@link AddItemToUsersPlaybackQueueRequest}.
+   */
+  public static final class Builder extends AbstractDataRequest.Builder<String, Builder>{
+
+    /**
+     * Create a new {@link AddItemToUsersPlaybackQueueRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-modify-playback-state} scope authorized in order to control playback.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
+    public Builder(final String accessToken) {
+      super(accessToken);
+    }
+
+    /**
+     * The device ID setter.
+     *
+     * @param device_id Optional. The ID of the device this command is targeting. If not supplied, the
+     *                  user's currently active device is the target.
+     * @return A {@link AddItemToUsersPlaybackQueueRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
+    public Builder device_id(final String device_id) {
+      assert (device_id != null);
+      assert (!device_id.equals(""));
+      return setQueryParameter("device_id", device_id);
+    }
+
+    /**
+     * The uri setter.
+     *
+     * @param uri Required. The uri of the item to add to the queue.
+     *            Must be a track or an episode uri.
+     * @return A {@link AddItemToUsersPlaybackQueueRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids">Spotify: URIs &amp; IDs</a>
+     */
+    public Builder uri(final String uri){
+      assert (uri != null);
+      assert (!uri.equals(""));
+      return setQueryParameter("uri", uri);
+    }
+
+
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link AddItemToUsersPlaybackQueueRequest}.
+     */
+    @Override
+    public AddItemToUsersPlaybackQueueRequest build() {
+      setContentType(ContentType.APPLICATION_JSON);
+      setPath("/v1/me/player/queue");
+      return new AddItemToUsersPlaybackQueueRequest(this);
+    }
+  }
+
+}

--- a/src/test/java/com/wrapper/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
+++ b/src/test/java/com/wrapper/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
@@ -1,0 +1,52 @@
+package com.wrapper.spotify.requests.data.player;
+
+import com.wrapper.spotify.TestUtil;
+import com.wrapper.spotify.exceptions.SpotifyWebApiException;
+import com.wrapper.spotify.requests.data.AbstractDataTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static com.wrapper.spotify.Assertions.assertHasHeader;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AddItemToUsersPlaybackQueueRequestTest extends AbstractDataTest<String>{
+  private final AddItemToUsersPlaybackQueueRequest defaultRequest = SPOTIFY_API
+    .addItemToUsersPlaybackQueue("spotify:track:" + ID_TRACK)
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson(
+        "requests/data/player/AddItemToUsersPlaybackQueueRequest.json"))
+    .device_id(DEVICE_ID)
+    .build();
+
+  public AddItemToUsersPlaybackQueueRequestTest() throws Exception {
+  }
+
+  @Test
+  public void shouldComplyWithReference() {
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertEquals("https://api.spotify.com:443/v1/me/player/queue?uri=spotify%3Atrack%3A01iyCAUm8EvOFqVWYJ3dVX&device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
+      defaultRequest.getUri().toString());
+  }
+
+  @Test
+  public void shouldReturnDefault_sync() throws IOException, SpotifyWebApiException {
+    shouldReturnDefault(defaultRequest.execute());
+  }
+
+  @Test
+  public void shouldReturnDefault_async() throws ExecutionException, InterruptedException {
+    shouldReturnDefault(defaultRequest.executeAsync().get());
+  }
+
+
+  public void shouldReturnDefault(String string) {
+    assertNull(
+      string);
+  }
+}

--- a/src/test/java/com/wrapper/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
+++ b/src/test/java/com/wrapper/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AddItemToUsersPlaybackQueueRequestTest extends AbstractDataTest<String>{
+public class AddItemToUsersPlaybackQueueRequestTest extends AbstractDataTest<String> {
   private final AddItemToUsersPlaybackQueueRequest defaultRequest = SPOTIFY_API
     .addItemToUsersPlaybackQueue("spotify:track:" + ID_TRACK)
     .setHttpManager(
@@ -44,9 +44,7 @@ public class AddItemToUsersPlaybackQueueRequestTest extends AbstractDataTest<Str
     shouldReturnDefault(defaultRequest.executeAsync().get());
   }
 
-
   public void shouldReturnDefault(String string) {
-    assertNull(
-      string);
+    assertNull(string);
   }
 }


### PR DESCRIPTION
adds support for new API-endpoint https://developer.spotify.com/documentation/web-api/reference/player/add-to-queue/
implements #194 