### PR TITLE
Change slf4j to api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
       <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.30</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <packaging>jar</packaging>


### PR DESCRIPTION
The slf4j-simple dependency conflicts with logback-classic.
As they both are implementations for the slf4j API the following will occur
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/duncte123/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.2.3/7c4f3c474fb2c041d8028740440937705ebb473a/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/duncte123/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/1.7.30/e606eac955f55ecf1d8edcccba04eb8ac98088dd/slf4j-simple-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
```

Luckily it selected the logback implementation but this could cause someone's logger to break without them knowing it was the slf4j-simple library.